### PR TITLE
#28 Stop doing zero-copy clone when transferring byte arrays to frame

### DIFF
--- a/src/shim/FrameMediator.ts
+++ b/src/shim/FrameMediator.ts
@@ -31,15 +31,14 @@ export class ShimMessenger {
     /**
      * Post request message to child iFrame
      * @param {RequestMessage} data         RequestMessage to post to child iFrame
-     * @param {Uint8Array[]}  transferList  List of byte arrays to transfer to frame
      */
-    postMessageToFrame(data: RequestMessage, transferList: Uint8Array[] = []): Future<SDKError, ResponseMessage> {
+    postMessageToFrame(data: RequestMessage): Future<SDKError, ResponseMessage> {
         const message: FrameEvent<RequestMessage> = {
             replyID: this.callbackCount++,
             data,
         };
         try {
-            this.messagePort.postMessage(message, transferList.map((int8Array) => int8Array.buffer));
+            this.messagePort.postMessage(message);
             return new Future<SDKError, ResponseMessage>((_, resolve) => {
                 this.callbacks[message.replyID] = resolve;
             });

--- a/src/shim/FrameMediator.ts
+++ b/src/shim/FrameMediator.ts
@@ -102,9 +102,9 @@ function isErrorResponse(response: ResponseMessage): response is ErrorResponse {
 /**
  * Post the provided RequestMessage to the SDK frame. Returns a Future which will be resolved with the provided ResponseMessage type, or rejected with an SDKError
  */
-export function sendMessage<T extends ResponseMessage>(payload: RequestMessage, transferList?: Uint8Array[]): Future<Error, T> {
+export function sendMessage<T extends ResponseMessage>(payload: RequestMessage): Future<Error, T> {
     return ensureFrameLoaded()
-        .flatMap(() => messenger.postMessageToFrame(payload, transferList))
+        .flatMap(() => messenger.postMessageToFrame(payload))
         .flatMap((response) => {
             //Handle all error messages generically here. Convert the message details back into an error object and reject the Future
             if (isErrorResponse(response)) {

--- a/src/shim/sdk/DocumentSDK.ts
+++ b/src/shim/sdk/DocumentSDK.ts
@@ -132,7 +132,7 @@ export function decrypt(documentID: string, documentData: Uint8Array) {
             documentData,
         },
     };
-    return FrameMediator.sendMessage<MT.DocumentDecryptResponse>(payload, [payload.message.documentData])
+    return FrameMediator.sendMessage<MT.DocumentDecryptResponse>(payload)
         .map(({message}) => message)
         .toPromise();
 }
@@ -177,7 +177,7 @@ export function encryptToStore(documentData: Uint8Array, options?: DocumentCreat
             policy: encryptOptions.policy,
         },
     };
-    return FrameMediator.sendMessage<MT.DocumentStoreEncryptResponse>(payload, [payload.message.documentData])
+    return FrameMediator.sendMessage<MT.DocumentStoreEncryptResponse>(payload)
         .map(({message}) => message)
         .toPromise();
 }
@@ -215,7 +215,7 @@ export function encrypt(documentData: Uint8Array, options?: DocumentCreateOption
             policy: encryptOptions.policy,
         },
     };
-    return FrameMediator.sendMessage<MT.DocumentEncryptResponse>(payload, [payload.message.documentData])
+    return FrameMediator.sendMessage<MT.DocumentEncryptResponse>(payload)
         .map(({message}) => message)
         .toPromise();
 }
@@ -246,7 +246,7 @@ export function updateEncryptedDataInStore(documentID: string, newDocumentData: 
             documentData: newDocumentData,
         },
     };
-    return FrameMediator.sendMessage<MT.DocumentStoreUpdateDataResponse>(payload, [payload.message.documentData])
+    return FrameMediator.sendMessage<MT.DocumentStoreUpdateDataResponse>(payload)
         .map(({message}) => message)
         .toPromise();
 }
@@ -267,7 +267,7 @@ export function updateEncryptedData(documentID: string, newDocumentData: Uint8Ar
             documentData: newDocumentData,
         },
     };
-    return FrameMediator.sendMessage<MT.DocumentUpdateDataResponse>(payload, [payload.message.documentData])
+    return FrameMediator.sendMessage<MT.DocumentUpdateDataResponse>(payload)
         .map(({message}) => message)
         .toPromise();
 }
@@ -365,7 +365,7 @@ export const advanced = {
                         documentData,
                     },
                 };
-                return FrameMediator.sendMessage<MT.DocumentUnmanagedDecryptResponse>(payload, [payload.message.documentData]).map(({message}) => ({
+                return FrameMediator.sendMessage<MT.DocumentUnmanagedDecryptResponse>(payload).map(({message}) => ({
                     data: message.data,
                     //There is no way to create a version 1 document with unmanaged edeks so this is safe.
                     documentID: documentId!,
@@ -400,7 +400,7 @@ export const advanced = {
                 policy: encryptOptions.policy,
             },
         };
-        return FrameMediator.sendMessage<MT.DocumentUnmanagedEncryptResponse>(payload, [payload.message.documentData])
+        return FrameMediator.sendMessage<MT.DocumentUnmanagedEncryptResponse>(payload)
             .map(({message}) => message)
             .toPromise();
     },

--- a/src/shim/sdk/tests/DocumentSDK.test.ts
+++ b/src/shim/sdk/tests/DocumentSDK.test.ts
@@ -1,11 +1,11 @@
-import * as DocumentSDK from "../DocumentSDK";
+import * as UTF8 from "@stablelib/utf8";
+import * as Base64 from "base64-js";
+import Future from "futurejs";
 import {ErrorCodes} from "../../../Constants";
+import {concatArrayBuffers} from "../../../lib/Utils";
 import * as FrameMediator from "../../FrameMediator";
 import * as ShimUtils from "../../ShimUtils";
-import Future from "futurejs";
-import * as Base64 from "base64-js";
-import * as UTF8 from "@stablelib/utf8";
-import {concatArrayBuffers} from "../../../lib/Utils";
+import * as DocumentSDK from "../DocumentSDK";
 
 describe("DocumentSDK", () => {
     beforeEach(() => {
@@ -206,16 +206,13 @@ describe("DocumentSDK", () => {
                     expect(result).toEqual({
                         data: new Uint8Array([98, 87]),
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_DECRYPT",
-                            message: {
-                                documentID: "mydoc",
-                                documentData: doc,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_DECRYPT",
+                        message: {
+                            documentID: "mydoc",
+                            documentData: doc,
                         },
-                        [doc]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -236,16 +233,13 @@ describe("DocumentSDK", () => {
                     expect(result).toEqual({
                         data: new Uint8Array([98, 87]),
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_DECRYPT",
-                            message: {
-                                documentID: "mydoc",
-                                documentData: doc,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_DECRYPT",
+                        message: {
+                            documentID: "mydoc",
+                            documentData: doc,
                         },
-                        [doc]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -265,16 +259,13 @@ describe("DocumentSDK", () => {
 
             DocumentSDK.decrypt("mydoc", doc)
                 .then(() => {
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_DECRYPT",
-                            message: {
-                                documentID: "mydoc",
-                                documentData: doc,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_DECRYPT",
+                        message: {
+                            documentID: "mydoc",
+                            documentData: doc,
                         },
-                        [doc]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -305,20 +296,17 @@ describe("DocumentSDK", () => {
             DocumentSDK.encryptToStore(document)
                 .then((result: any) => {
                     expect(result).toEqual("messageResponse");
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_STORE_ENCRYPT",
-                            message: {
-                                documentID: expect.any(String),
-                                documentData: document,
-                                documentName: "",
-                                userGrants: [],
-                                groupGrants: [],
-                                grantToAuthor: true,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_STORE_ENCRYPT",
+                        message: {
+                            documentID: expect.any(String),
+                            documentData: document,
+                            documentName: "",
+                            userGrants: [],
+                            groupGrants: [],
+                            grantToAuthor: true,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -330,20 +318,17 @@ describe("DocumentSDK", () => {
             DocumentSDK.encryptToStore(document, {grantToAuthor: false})
                 .then((result: any) => {
                     expect(result).toEqual("messageResponse");
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_STORE_ENCRYPT",
-                            message: {
-                                documentID: expect.any(String),
-                                documentData: document,
-                                documentName: "",
-                                userGrants: [],
-                                groupGrants: [],
-                                grantToAuthor: false,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_STORE_ENCRYPT",
+                        message: {
+                            documentID: expect.any(String),
+                            documentData: document,
+                            documentName: "",
+                            userGrants: [],
+                            groupGrants: [],
+                            grantToAuthor: false,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -354,20 +339,17 @@ describe("DocumentSDK", () => {
             const document = new Uint8Array([100, 111, 99]);
             DocumentSDK.encryptToStore(document, {documentID: "provideID"})
                 .then(() => {
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_STORE_ENCRYPT",
-                            message: {
-                                documentID: "provideID",
-                                documentData: document,
-                                documentName: "",
-                                userGrants: [],
-                                groupGrants: [],
-                                grantToAuthor: true,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_STORE_ENCRYPT",
+                        message: {
+                            documentID: "provideID",
+                            documentData: document,
+                            documentName: "",
+                            userGrants: [],
+                            groupGrants: [],
+                            grantToAuthor: true,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -378,20 +360,17 @@ describe("DocumentSDK", () => {
             const document = new Uint8Array([100, 111, 99]);
             DocumentSDK.encryptToStore(document, {documentName: "my doc"})
                 .then(() => {
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_STORE_ENCRYPT",
-                            message: {
-                                documentID: expect.any(String),
-                                documentData: document,
-                                documentName: "my doc",
-                                userGrants: [],
-                                groupGrants: [],
-                                grantToAuthor: true,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_STORE_ENCRYPT",
+                        message: {
+                            documentID: expect.any(String),
+                            documentData: document,
+                            documentName: "my doc",
+                            userGrants: [],
+                            groupGrants: [],
+                            grantToAuthor: true,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -404,20 +383,17 @@ describe("DocumentSDK", () => {
             const groupList = [{id: "group-1"}, {id: "group-2"}, {id: "group-3"}];
             DocumentSDK.encryptToStore(document, {documentName: "my doc name", accessList: {users: userList, groups: groupList}})
                 .then(() => {
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_STORE_ENCRYPT",
-                            message: {
-                                documentID: expect.any(String),
-                                documentData: document,
-                                documentName: "my doc name",
-                                userGrants: ["user-31", "user-55"],
-                                groupGrants: ["group-1", "group-2", "group-3"],
-                                grantToAuthor: true,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_STORE_ENCRYPT",
+                        message: {
+                            documentID: expect.any(String),
+                            documentData: document,
+                            documentName: "my doc name",
+                            userGrants: ["user-31", "user-55"],
+                            groupGrants: ["group-1", "group-2", "group-3"],
+                            grantToAuthor: true,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -472,20 +448,17 @@ describe("DocumentSDK", () => {
                         created: "1",
                         updated: "2",
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_ENCRYPT",
-                            message: {
-                                documentID: expect.any(String),
-                                documentData: document,
-                                documentName: "",
-                                userGrants: [],
-                                groupGrants: [],
-                                grantToAuthor: true,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_ENCRYPT",
+                        message: {
+                            documentID: expect.any(String),
+                            documentData: document,
+                            documentName: "",
+                            userGrants: [],
+                            groupGrants: [],
+                            grantToAuthor: true,
                         },
-                        [document]
-                    );
+                    });
                     const messagePayload = (FrameMediator.sendMessage as jasmine.Spy).calls.argsFor(0)[0];
                     expect(messagePayload.message.documentID.length).toEqual(32);
                     expect(messagePayload.message.documentID).toMatch(/[0-9a-fA-F]+/);
@@ -511,20 +484,17 @@ describe("DocumentSDK", () => {
                     expect(result).toEqual({
                         document: encryptedDoc,
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_ENCRYPT",
-                            message: {
-                                documentID: expect.any(String),
-                                documentData: document,
-                                documentName: "",
-                                userGrants: [],
-                                groupGrants: [],
-                                grantToAuthor: false,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_ENCRYPT",
+                        message: {
+                            documentID: expect.any(String),
+                            documentData: document,
+                            documentName: "",
+                            userGrants: [],
+                            groupGrants: [],
+                            grantToAuthor: false,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -547,20 +517,17 @@ describe("DocumentSDK", () => {
                     expect(result).toEqual({
                         document: encryptedDoc,
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_ENCRYPT",
-                            message: {
-                                documentID: "providedID",
-                                documentData: document,
-                                documentName: "",
-                                userGrants: [],
-                                groupGrants: [],
-                                grantToAuthor: true,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_ENCRYPT",
+                        message: {
+                            documentID: "providedID",
+                            documentData: document,
+                            documentName: "",
+                            userGrants: [],
+                            groupGrants: [],
+                            grantToAuthor: true,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -583,20 +550,17 @@ describe("DocumentSDK", () => {
                     expect(result).toEqual({
                         document: encryptedDoc,
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_ENCRYPT",
-                            message: {
-                                documentID: expect.any(String),
-                                documentData: document,
-                                documentName: "my doc name",
-                                userGrants: [],
-                                groupGrants: [],
-                                grantToAuthor: true,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_ENCRYPT",
+                        message: {
+                            documentID: expect.any(String),
+                            documentData: document,
+                            documentName: "my doc name",
+                            userGrants: [],
+                            groupGrants: [],
+                            grantToAuthor: true,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -622,20 +586,17 @@ describe("DocumentSDK", () => {
                     expect(result).toEqual({
                         document: encryptedDoc,
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_ENCRYPT",
-                            message: {
-                                documentID: expect.any(String),
-                                documentData: document,
-                                documentName: "",
-                                userGrants: ["user-31", "user-55"],
-                                groupGrants: ["group-1", "group-2", "group-3"],
-                                grantToAuthor: true,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_ENCRYPT",
+                        message: {
+                            documentID: expect.any(String),
+                            documentData: document,
+                            documentName: "",
+                            userGrants: ["user-31", "user-55"],
+                            groupGrants: ["group-1", "group-2", "group-3"],
+                            grantToAuthor: true,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -665,16 +626,13 @@ describe("DocumentSDK", () => {
             DocumentSDK.updateEncryptedDataInStore("mydoc", document)
                 .then((result: any) => {
                     expect(result).toEqual("messageResponse");
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_STORE_UPDATE_DATA",
-                            message: {
-                                documentID: "mydoc",
-                                documentData: document,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_STORE_UPDATE_DATA",
+                        message: {
+                            documentID: "mydoc",
+                            documentData: document,
                         },
-                        [document]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -723,16 +681,13 @@ describe("DocumentSDK", () => {
                         documentID: "doc-10",
                         document: encryptedDoc,
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_UPDATE_DATA",
-                            message: {
-                                documentID: "mydoc",
-                                documentData: doc,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_UPDATE_DATA",
+                        message: {
+                            documentID: "mydoc",
+                            documentData: doc,
                         },
-                        [doc]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -755,16 +710,13 @@ describe("DocumentSDK", () => {
                     expect(result).toEqual({
                         document: encryptedDoc,
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_UPDATE_DATA",
-                            message: {
-                                documentID: "mydoc",
-                                documentData: doc,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_UPDATE_DATA",
+                        message: {
+                            documentID: "mydoc",
+                            documentData: doc,
                         },
-                        [doc]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));
@@ -1004,16 +956,13 @@ describe("DocumentSDK", () => {
                         data: new Uint8Array([98, 87]),
                         documentID: "353",
                     });
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith(
-                        {
-                            type: "DOCUMENT_UNMANAGED_DECRYPT",
-                            message: {
-                                edeks: nonEmptyEdeks,
-                                documentData: doc,
-                            },
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DOCUMENT_UNMANAGED_DECRYPT",
+                        message: {
+                            edeks: nonEmptyEdeks,
+                            documentData: doc,
                         },
-                        [doc]
-                    );
+                    });
                     done();
                 })
                 .catch((e) => fail(e.message));

--- a/src/shim/tests/FrameMediator.test.ts
+++ b/src/shim/tests/FrameMediator.test.ts
@@ -1,6 +1,6 @@
 import Future from "futurejs";
-import {sendMessage, messenger, ShimMessenger} from "../FrameMediator";
 import {Frame} from "../../Constants";
+import {messenger, sendMessage, ShimMessenger} from "../FrameMediator";
 
 describe("FrameMediator", () => {
     describe("ShimMessenger", () => {
@@ -123,11 +123,11 @@ describe("FrameMediator", () => {
                     foo: "bar",
                 })
             );
-            sendMessage({payload: "content"} as any, [new Uint8Array(12), new Uint8Array(10)]).engage(
+            sendMessage({payload: "content"} as any).engage(
                 (e) => fail(e),
                 (result: any) => {
                     expect(result).toEqual({foo: "bar"});
-                    expect(messenger.postMessageToFrame).toHaveBeenCalledWith({payload: "content"}, [new Uint8Array(12), new Uint8Array(10)]);
+                    expect(messenger.postMessageToFrame).toHaveBeenCalledWith({payload: "content"});
                 }
             );
         });

--- a/src/shim/tests/FrameMediator.test.ts
+++ b/src/shim/tests/FrameMediator.test.ts
@@ -40,7 +40,7 @@ describe("FrameMediator", () => {
                     }
                 );
 
-                expect(messenger.messagePort.postMessage).toHaveBeenCalledWith({data: {foo: "bar"}, replyID: 0}, []);
+                expect(messenger.messagePort.postMessage).toHaveBeenCalledWith({data: {foo: "bar"}, replyID: 0});
                 expect(messenger.callbackCount).toEqual(1);
                 expect(messenger.callbacks).toEqual({
                     0: expect.any(Function),
@@ -55,7 +55,7 @@ describe("FrameMediator", () => {
                     postMessage: jasmine.createSpy("postMessage"),
                 };
 
-                messenger.postMessageToFrame({foo: "bar"} as any, [{buffer: "1"}, {buffer: "2"}] as any).engage(
+                messenger.postMessageToFrame({foo: "bar"} as any).engage(
                     (e) => fail(e.message),
                     (result: any) => {
                         expect(result).toEqual({engaged: "future"});
@@ -63,7 +63,7 @@ describe("FrameMediator", () => {
                     }
                 );
 
-                expect(messenger.messagePort.postMessage).toHaveBeenCalledWith({data: {foo: "bar"}, replyID: 0}, ["1", "2"]);
+                expect(messenger.messagePort.postMessage).toHaveBeenCalledWith({data: {foo: "bar"}, replyID: 0});
                 expect(messenger.callbacks).toEqual({
                     0: expect.any(Function),
                 });


### PR DESCRIPTION
Zeroing out byte arrays on transfer to the frame can cause any number of confusing situations. Especially when dealing with protobuf encoded arrays or other scenarios where the view provided to IronWeb is a subset of the data. Instead, change this to do a copy on transfer to the frame which will have a minor impact on performance but prevent confusing clearing of data on input.