### PR TITLE
Adding Schnorr signature to request when adding members to group

### DIFF
--- a/src/WorkerMessageTypes.d.ts
+++ b/src/WorkerMessageTypes.d.ts
@@ -189,6 +189,8 @@ export interface GroupAddMemberWorkerRequest {
     type: "GROUP_ADD_MEMBERS";
     message: {
         encryptedGroupKey: TransformedEncryptedMessage;
+        groupID: string;
+        groupPublicKey: PublicKey<string>;
         userKeyList: UserOrGroupPublicKey[];
         adminPrivateKey: PrivateKey<Uint8Array>;
         signingKeys: SigningKeyPair;
@@ -196,7 +198,10 @@ export interface GroupAddMemberWorkerRequest {
 }
 export interface GroupAddMemberWorkerResponse {
     type: "GROUP_ADD_MEMBERS_RESPONSE";
-    message: TransformKeyGrant[];
+    message: {
+        transformKeyGrant: TransformKeyGrant[];
+        signature: Uint8Array;
+    };
 }
 
 export interface SignatureGenerationWorkerRequest {

--- a/src/frame/endpoints/GroupApiEndpoints.ts
+++ b/src/frame/endpoints/GroupApiEndpoints.ts
@@ -6,6 +6,7 @@ import {publicKeyToBase64, transformKeyToBase64} from "../../lib/Utils";
 import {makeAuthorizedApiRequest} from "../ApiRequest";
 import ApiState from "../ApiState";
 import {TransformKeyGrant} from "../worker/crypto/recrypt";
+import {fromByteArray} from "base64-js";
 
 export interface GroupListResponseType {
     result: GroupApiFullResponse[];
@@ -187,7 +188,7 @@ function addMembers(groupID: string, addedMembers: TransformKeyGrant[], signatur
                     userMasterPublicKey: member.publicKey,
                     transformKey: transformKeyToBase64(member.transformKey),
                 })),
-                signature,
+                signature: fromByteArray(signature),
             }),
         },
         errorCode: ErrorCodes.GROUP_ADD_MEMBERS_REQUEST_FAILURE,

--- a/src/frame/endpoints/GroupApiEndpoints.ts
+++ b/src/frame/endpoints/GroupApiEndpoints.ts
@@ -173,7 +173,7 @@ function removeAdmins(groupID: string, removedAdmins: string[]) {
  * @param {string}              groupID      ID of group to add members to
  * @param {TransformKeyGrant[]} addedMembers List of member transform keys to add
  */
-function addMembers(groupID: string, addedMembers: TransformKeyGrant[]) {
+function addMembers(groupID: string, addedMembers: TransformKeyGrant[], signature: Uint8Array) {
     return {
         url: `groups/${encodeURIComponent(groupID)}/users`,
         options: {
@@ -187,6 +187,7 @@ function addMembers(groupID: string, addedMembers: TransformKeyGrant[]) {
                     userMasterPublicKey: member.publicKey,
                     transformKey: transformKeyToBase64(member.transformKey),
                 })),
+                signature,
             }),
         },
         errorCode: ErrorCodes.GROUP_ADD_MEMBERS_REQUEST_FAILURE,
@@ -319,8 +320,8 @@ export default {
      * @param {string}              groupID    ID of the group to add members to
      * @param {TransformKeyGrant[]} memberList List of users and transform keys to add to group
      */
-    callAddMembersApi(groupID: string, memberList: TransformKeyGrant[]) {
-        const {url, options, errorCode} = addMembers(groupID, memberList);
+    callAddMembersApi(groupID: string, memberList: TransformKeyGrant[], signature: Uint8Array) {
+        const {url, options, errorCode} = addMembers(groupID, memberList, signature);
         return makeAuthorizedApiRequest<GroupMemberModifyResponseType>(url, errorCode, options);
     },
 

--- a/src/frame/endpoints/tests/GroupApiEndpoints.test.ts
+++ b/src/frame/endpoints/tests/GroupApiEndpoints.test.ts
@@ -343,8 +343,9 @@ describe("GroupApiEndpoints", () => {
                     id: "99",
                 },
             ];
+            const signature = new Uint8Array(32);
 
-            GroupApiEndpoints.callAddMembersApi("31", userKeys).engage(
+            GroupApiEndpoints.callAddMembersApi("31", userKeys, signature).engage(
                 (e) => fail(e),
                 (addResult: any) => {
                     expect(addResult).toEqual({foo: "bar"});
@@ -378,6 +379,7 @@ describe("GroupApiEndpoints", () => {
                                 },
                             },
                         ],
+                        signature: signature,
                     });
                 }
             );

--- a/src/frame/endpoints/tests/GroupApiEndpoints.test.ts
+++ b/src/frame/endpoints/tests/GroupApiEndpoints.test.ts
@@ -343,7 +343,7 @@ describe("GroupApiEndpoints", () => {
                     id: "99",
                 },
             ];
-            const signature = new Uint8Array(32);
+            const signature = new Uint8Array([98, 103, 110]);
 
             GroupApiEndpoints.callAddMembersApi("31", userKeys, signature).engage(
                 (e) => fail(e),
@@ -379,7 +379,7 @@ describe("GroupApiEndpoints", () => {
                                 },
                             },
                         ],
-                        signature: signature,
+                        signature: "Ymdu",
                     });
                 }
             );

--- a/src/frame/sdk/GroupApi.ts
+++ b/src/frame/sdk/GroupApi.ts
@@ -169,8 +169,15 @@ export function addMembers(groupID: string, userList: string[]) {
                 );
             }
             const userPublicKeys = userKeys.result.map((user) => ({id: user.id, masterPublicKey: user.userMasterPublicKey}));
-            return GroupOperations.generateGroupTransformKeyToList(group.encryptedPrivateKey, userPublicKeys, privateKey, ApiState.signingKeys())
-                .flatMap((userKeyList) => GroupApiEndpoints.callAddMembersApi(groupID, userKeyList))
+            return GroupOperations.generateGroupTransformKeyToListAndSignature(
+                group.encryptedPrivateKey,
+                group.groupMasterPublicKey,
+                groupID,
+                userPublicKeys,
+                privateKey,
+                ApiState.signingKeys()
+            )
+                .flatMap(({transformKeyGrant, signature}) => GroupApiEndpoints.callAddMembersApi(groupID, transformKeyGrant, signature))
                 .map(({failedIds, succeededIds}) => mapOperationToSuccessAndFailureList(userList, succeededIds, failedIds));
         }
     );

--- a/src/frame/sdk/GroupApi.ts
+++ b/src/frame/sdk/GroupApi.ts
@@ -169,6 +169,7 @@ export function addMembers(groupID: string, userList: string[]) {
                 );
             }
             const userPublicKeys = userKeys.result.map((user) => ({id: user.id, masterPublicKey: user.userMasterPublicKey}));
+            console.log(group);
             return GroupOperations.generateGroupTransformKeyToListAndSignature(
                 group.encryptedPrivateKey,
                 group.groupMasterPublicKey,

--- a/src/frame/sdk/GroupApi.ts
+++ b/src/frame/sdk/GroupApi.ts
@@ -169,8 +169,7 @@ export function addMembers(groupID: string, userList: string[]) {
                 );
             }
             const userPublicKeys = userKeys.result.map((user) => ({id: user.id, masterPublicKey: user.userMasterPublicKey}));
-            console.log(group);
-            return GroupOperations.generateGroupTransformKeyToListAndSignature(
+            return GroupOperations.generateGroupTransformKeyToList(
                 group.encryptedPrivateKey,
                 group.groupMasterPublicKey,
                 groupID,

--- a/src/frame/sdk/GroupOperations.ts
+++ b/src/frame/sdk/GroupOperations.ts
@@ -44,6 +44,8 @@ export function encryptGroupPrivateKeyToList(
 /**
  * Send message to worker to decrypt the groups private key and generate transform keys from it to the list of user public keys provided.
  * @param {TransformedEncryptedMessage} encryptedGroupPrivateKey Response from group GET call
+ * @param {PublicKey<string>}           groupPublicKey           Group public key of the group being added to
+ * @param {string}                      groupID                  Group Id of the group being added to
  * @param {UserOrGroupPublicKey[]}      userKeyList              List of public keys to generate transform keys to
  * @param {PrivateKey<Uint8Array>}      myPrivateKey             Private key of current, admin user
  * @param {SigningKeyPair}              signingKeys              Current users signing keys

--- a/src/frame/sdk/GroupOperations.ts
+++ b/src/frame/sdk/GroupOperations.ts
@@ -48,8 +48,10 @@ export function encryptGroupPrivateKeyToList(
  * @param {PrivateKey<Uint8Array>}      myPrivateKey             Private key of current, admin user
  * @param {SigningKeyPair}              signingKeys              Current users signing keys
  */
-export function generateGroupTransformKeyToList(
+export function generateGroupTransformKeyToListAndSignature(
     encryptedGroupPrivateKey: TransformedEncryptedMessage,
+    groupPublicKey: PublicKey<string>,
+    groupID: string,
     userKeyList: UserOrGroupPublicKey[],
     myPrivateKey: PrivateKey<Uint8Array>,
     signingKeys: SigningKeyPair
@@ -58,6 +60,8 @@ export function generateGroupTransformKeyToList(
         type: "GROUP_ADD_MEMBERS",
         message: {
             encryptedGroupKey: encryptedGroupPrivateKey,
+            groupPublicKey,
+            groupID,
             userKeyList,
             adminPrivateKey: myPrivateKey,
             signingKeys,

--- a/src/frame/sdk/GroupOperations.ts
+++ b/src/frame/sdk/GroupOperations.ts
@@ -48,7 +48,7 @@ export function encryptGroupPrivateKeyToList(
  * @param {PrivateKey<Uint8Array>}      myPrivateKey             Private key of current, admin user
  * @param {SigningKeyPair}              signingKeys              Current users signing keys
  */
-export function generateGroupTransformKeyToListAndSignature(
+export function generateGroupTransformKeyToList(
     encryptedGroupPrivateKey: TransformedEncryptedMessage,
     groupPublicKey: PublicKey<string>,
     groupID: string,

--- a/src/frame/sdk/tests/GroupApi.test.ts
+++ b/src/frame/sdk/tests/GroupApi.test.ts
@@ -416,7 +416,7 @@ describe("GroupApi", () => {
                 Future.of({
                     groupID: "32",
                     encryptedPrivateKey: "encryptedPrivKey",
-                    groupPublicKey: "groupPublicKey",
+                    groupMasterPublicKey: {x: "12", y: "23"},
                     GroupID: "groupID",
                     permissions: ["admin", "member"],
                     adminIds: ["id1"],
@@ -446,8 +446,8 @@ describe("GroupApi", () => {
                     expect(GroupApiEndpoints.callAddMembersApi).toHaveBeenCalledWith("61", ["transformKey1", "transformKey2"], signature);
                     expect(GroupOperations.generateGroupTransformKeyToListAndSignature).toHaveBeenCalledWith(
                         "encryptedPrivKey",
-                        "groupPublicKey",
-                        "groupID",
+                        {x: "12", y: "23"},
+                        "61",
                         [{id: "id1", masterPublicKey: {x: "key1"}}, {id: "id2", masterPublicKey: {x: "key2"}}],
                         expect.any(Uint8Array),
                         ApiState.signingKeys()

--- a/src/frame/sdk/tests/GroupApi.test.ts
+++ b/src/frame/sdk/tests/GroupApi.test.ts
@@ -417,7 +417,6 @@ describe("GroupApi", () => {
                     groupID: "32",
                     encryptedPrivateKey: "encryptedPrivKey",
                     groupMasterPublicKey: {x: "12", y: "23"},
-                    GroupID: "groupID",
                     permissions: ["admin", "member"],
                     adminIds: ["id1"],
                 })

--- a/src/frame/sdk/tests/GroupApi.test.ts
+++ b/src/frame/sdk/tests/GroupApi.test.ts
@@ -429,7 +429,7 @@ describe("GroupApi", () => {
                     failedIds: [{userId: "12", errorMessage: "does not exist"}],
                 })
             );
-            spyOn(GroupOperations, "generateGroupTransformKeyToListAndSignature").and.returnValue(
+            spyOn(GroupOperations, "generateGroupTransformKeyToList").and.returnValue(
                 Future.of({transformKeyGrant: ["transformKey1", "transformKey2"], signature})
             );
 
@@ -444,7 +444,7 @@ describe("GroupApi", () => {
                     expect(GroupApiEndpoints.callGroupGetApi).toHaveBeenCalledWith("61");
                     expect(UserApiEndpoints.callUserKeyListApi).toHaveBeenCalledWith(["user1", "user2"]);
                     expect(GroupApiEndpoints.callAddMembersApi).toHaveBeenCalledWith("61", ["transformKey1", "transformKey2"], signature);
-                    expect(GroupOperations.generateGroupTransformKeyToListAndSignature).toHaveBeenCalledWith(
+                    expect(GroupOperations.generateGroupTransformKeyToList).toHaveBeenCalledWith(
                         "encryptedPrivKey",
                         {x: "12", y: "23"},
                         "61",
@@ -463,7 +463,7 @@ describe("GroupApi", () => {
                 Future.of({groupID: "32", encryptedPrivateKey: "encryptedPrivKey", permissions: ["admin", "member"]})
             );
             spyOn(UserApiEndpoints, "callUserKeyListApi").and.returnValue(Future.of({result: []}));
-            spyOn(GroupOperations, "generateGroupTransformKeyToListAndSignature");
+            spyOn(GroupOperations, "generateGroupTransformKeyToList");
 
             GroupApi.addMembers("61", ["user1", "user2"]).engage(
                 (e) => fail(e),
@@ -475,7 +475,7 @@ describe("GroupApi", () => {
 
                     expect(GroupApiEndpoints.callGroupGetApi).toHaveBeenCalledWith("61");
                     expect(UserApiEndpoints.callUserKeyListApi).toHaveBeenCalledWith(["user1", "user2"]);
-                    expect(GroupOperations.generateGroupTransformKeyToListAndSignature).not.toHaveBeenCalled();
+                    expect(GroupOperations.generateGroupTransformKeyToList).not.toHaveBeenCalled();
                     done();
                 }
             );
@@ -520,7 +520,7 @@ describe("GroupApi", () => {
                     failedIds: [{userId: "12", errorMessage: "does not exist"}],
                 })
             );
-            spyOn(GroupOperations, "generateGroupTransformKeyToListAndSignature").and.returnValue(Future.of(["transformKey1", "transformKey2"]));
+            spyOn(GroupOperations, "generateGroupTransformKeyToList").and.returnValue(Future.of(["transformKey1", "transformKey2"]));
 
             GroupApi.addMembers("61", ["user1", "user2", "12"]).engage(
                 (e) => fail(e),

--- a/src/frame/sdk/tests/GroupOperations.test.ts
+++ b/src/frame/sdk/tests/GroupOperations.test.ts
@@ -77,7 +77,7 @@ describe("GroupOperations", () => {
         });
     });
 
-    describe("generateGroupTransformKeyToListAndSignature", () => {
+    describe("generateGroupTransformKeyToList", () => {
         it("sends message to worker to generate transform key to list", () => {
             spyOn(WorkerMediator, "sendMessage").and.returnValue(Future.of({message: "transformed user keys"}));
             const userPrivateKey = new Uint8Array(32);
@@ -86,14 +86,7 @@ describe("GroupOperations", () => {
             const signingKeys = TestUtils.getSigningKeyPair();
             const groupPublicKey = TestUtils.getEmptyPublicKeyString();
 
-            GroupOperations.generateGroupTransformKeyToListAndSignature(
-                encryptedGroupPrivateKey,
-                groupPublicKey,
-                "GroupID",
-                userList,
-                userPrivateKey,
-                signingKeys
-            ).engage(
+            GroupOperations.generateGroupTransformKeyToList(encryptedGroupPrivateKey, groupPublicKey, "GroupID", userList, userPrivateKey, signingKeys).engage(
                 (e) => fail(e),
                 (result: any) => {
                     expect(result).toEqual("transformed user keys");

--- a/src/frame/sdk/tests/GroupOperations.test.ts
+++ b/src/frame/sdk/tests/GroupOperations.test.ts
@@ -77,15 +77,23 @@ describe("GroupOperations", () => {
         });
     });
 
-    describe("generateGroupTransformKeyToList", () => {
+    describe("generateGroupTransformKeyToListAndSignature", () => {
         it("sends message to worker to generate transform key to list", () => {
             spyOn(WorkerMediator, "sendMessage").and.returnValue(Future.of({message: "transformed user keys"}));
             const userPrivateKey = new Uint8Array(32);
             const userList = [{id: "user-35", masterPublicKey: {x: "", y: ""}}];
             const encryptedGroupPrivateKey = TestUtils.getTransformedSymmetricKey();
             const signingKeys = TestUtils.getSigningKeyPair();
+            const groupPublicKey = TestUtils.getEmptyPublicKeyString();
 
-            GroupOperations.generateGroupTransformKeyToList(encryptedGroupPrivateKey, userList, userPrivateKey, signingKeys).engage(
+            GroupOperations.generateGroupTransformKeyToListAndSignature(
+                encryptedGroupPrivateKey,
+                groupPublicKey,
+                "GroupID",
+                userList,
+                userPrivateKey,
+                signingKeys
+            ).engage(
                 (e) => fail(e),
                 (result: any) => {
                     expect(result).toEqual("transformed user keys");
@@ -94,6 +102,8 @@ describe("GroupOperations", () => {
                         type: "GROUP_ADD_MEMBERS",
                         message: {
                             encryptedGroupKey: encryptedGroupPrivateKey,
+                            groupPublicKey: groupPublicKey,
+                            groupID: "GroupID",
                             userKeyList: userList,
                             adminPrivateKey: userPrivateKey,
                             signingKeys,

--- a/src/frame/worker/GroupCrypto.ts
+++ b/src/frame/worker/GroupCrypto.ts
@@ -70,12 +70,9 @@ export function addMembersToGroup(
     return loadRecrypt()
         .flatMap((Recrypt) => {
             return Recrypt.decryptPlaintext(encryptedGroupPrivateKey, adminPrivateKey).flatMap(([_, key]) => {
-                return Future.gather2(
-                    Recrypt.generateTransformKeyToList(key, userKeyList, signingKeys),
-                    Future.of(Recrypt.schnorrSignUtf8String(key, publicKeyToBytes(groupPublicKey), groupID))
-                ).map(([transformKeyGrant, signature]) => ({
+                return Recrypt.generateTransformKeyToList(key, userKeyList, signingKeys).map((transformKeyGrant) => ({
                     transformKeyGrant,
-                    signature,
+                    signature: Recrypt.schnorrSignUtf8String(key, publicKeyToBytes(groupPublicKey), groupID),
                 }));
             });
         })

--- a/src/frame/worker/GroupCrypto.ts
+++ b/src/frame/worker/GroupCrypto.ts
@@ -2,6 +2,7 @@ import loadRecrypt from "./crypto/recrypt";
 import Future from "futurejs";
 import SDKError from "../../lib/SDKError";
 import {ErrorCodes} from "../../Constants";
+import {publicKeyToBytes} from "../../lib/Utils";
 
 /**
  * Create the keys for a new group. Generates a new keypair for the group and encrypts the value used to generate the
@@ -71,7 +72,7 @@ export function addMembersToGroup(
             return Recrypt.decryptPlaintext(encryptedGroupPrivateKey, adminPrivateKey).flatMap(([_, key]) => {
                 return Future.gather2(
                     Recrypt.generateTransformKeyToList(key, userKeyList, signingKeys),
-                    Future.of(Recrypt.schnorrSignUtf8String(key, groupPublicKey, groupID))
+                    Future.of(Recrypt.schnorrSignUtf8String(key, publicKeyToBytes(groupPublicKey), groupID))
                 ).map(([transformKeyGrant, signature]) => ({
                     transformKeyGrant,
                     signature,

--- a/src/frame/worker/GroupCrypto.ts
+++ b/src/frame/worker/GroupCrypto.ts
@@ -66,10 +66,10 @@ export function addMembersToGroup(
 ) {
     return loadRecrypt()
         .flatMap((Recrypt) => {
-            return Recrypt.decryptPlaintext(encryptedGroupPrivateKey, adminPrivateKey).flatMap(([groupPrivateKey, key]) => {
+            return Recrypt.decryptPlaintext(encryptedGroupPrivateKey, adminPrivateKey).flatMap(([_, key]) => {
                 return Future.gather2(
                     Recrypt.generateTransformKeyToList(key, userKeyList, signingKeys),
-                    Recrypt.generateAddMemberSignature(groupPrivateKey, groupPublicKey, groupID)
+                    Recrypt.generateAddMemberSignature(key, groupPublicKey, groupID)
                 ).map(([transformKeyGrant, signature]) => ({
                     transformKeyGrant,
                     signature,

--- a/src/frame/worker/GroupCrypto.ts
+++ b/src/frame/worker/GroupCrypto.ts
@@ -50,8 +50,10 @@ export function addAdminsToGroup(
 }
 
 /**
- * Decrypt the provided group private key and use it to generate transform keys to each public user key provided.
+ * Decrypt the provided group private key and use it to generate Schnorr signature and transform keys to each public user key provided.
  * @param {TransformedEncryptedMessage} groupPrivateKey Encrypted private key for group
+ * @param {PublicKey<string>}           groupPublicKey  Group public key of the group being added to
+ * @param {string}                      groupID         Group Id of the group being added to
  * @param {UserOrGroupPublicKey[]}      userKeyList     List of user public keys to generate transform keys to
  * @param {PrivateKey<Uint8Array>}      adminPrivateKey Private key of the group add who is adding these new members.
  * @param {SigningKeyPair}              signingKeys     Current users signing keys used to sign transform key

--- a/src/frame/worker/GroupCrypto.ts
+++ b/src/frame/worker/GroupCrypto.ts
@@ -71,7 +71,7 @@ export function addMembersToGroup(
             return Recrypt.decryptPlaintext(encryptedGroupPrivateKey, adminPrivateKey).flatMap(([_, key]) => {
                 return Future.gather2(
                     Recrypt.generateTransformKeyToList(key, userKeyList, signingKeys),
-                    Recrypt.generateAddMemberSignature(key, groupPublicKey, groupID)
+                    Future.of(Recrypt.schnorrSignUtf8String(key, groupPublicKey, groupID))
                 ).map(([transformKeyGrant, signature]) => ({
                     transformKeyGrant,
                     signature,

--- a/src/frame/worker/crypto/recrypt/RecryptWasm.ts
+++ b/src/frame/worker/crypto/recrypt/RecryptWasm.ts
@@ -248,6 +248,10 @@ export const createRequestSignature = (
     };
 };
 
+export const generateAddMemberSignature = (groupPrivateKey: Uint8Array, groupPublicKey: PublicKey<string>, groupId: string) => {
+    return Future.of(RecryptApi.schnorrSign(groupPrivateKey, publicKeyToBytes(groupPublicKey), utf8StringToArrayBuffer(groupId)));
+};
+
 /**
  * Generate a signature to be used as part of a device add operation
  * @param {String}       jwtToken          JWT token authorizing the current user

--- a/src/frame/worker/crypto/recrypt/RecryptWasm.ts
+++ b/src/frame/worker/crypto/recrypt/RecryptWasm.ts
@@ -248,6 +248,12 @@ export const createRequestSignature = (
     };
 };
 
+/**
+ * Generate a schnorr signature using the group's private key over the group's provided id
+ * @param groupPrivateKey
+ * @param groupPublicKey
+ * @param groupId
+ */
 export const generateAddMemberSignature = (groupPrivateKey: Uint8Array, groupPublicKey: PublicKey<string>, groupId: string) => {
     return Future.of(RecryptApi.schnorrSign(groupPrivateKey, publicKeyToBytes(groupPublicKey), utf8StringToArrayBuffer(groupId)));
 };

--- a/src/frame/worker/crypto/recrypt/RecryptWasm.ts
+++ b/src/frame/worker/crypto/recrypt/RecryptWasm.ts
@@ -249,10 +249,10 @@ export const createRequestSignature = (
 };
 
 /**
- * Generate a schnorr signature using the group's private key over the group's provided id
+ * Generate a schnorr signature using the private key over the provided id
  */
-export const schnorrSignUtf8String = (privateKey: Uint8Array, publicKey: PublicKey<string>, string: string) => {
-    return RecryptApi.schnorrSign(privateKey, publicKeyToBytes(publicKey), utf8StringToArrayBuffer(string));
+export const schnorrSignUtf8String = (privateKey: Uint8Array, publicKey: PublicKey<Uint8Array>, string: string) => {
+    return RecryptApi.schnorrSign(privateKey, publicKey, utf8StringToArrayBuffer(string));
 };
 
 /**

--- a/src/frame/worker/crypto/recrypt/RecryptWasm.ts
+++ b/src/frame/worker/crypto/recrypt/RecryptWasm.ts
@@ -250,12 +250,9 @@ export const createRequestSignature = (
 
 /**
  * Generate a schnorr signature using the group's private key over the group's provided id
- * @param groupPrivateKey
- * @param groupPublicKey
- * @param groupId
  */
-export const generateAddMemberSignature = (groupPrivateKey: Uint8Array, groupPublicKey: PublicKey<string>, groupId: string) => {
-    return Future.of(RecryptApi.schnorrSign(groupPrivateKey, publicKeyToBytes(groupPublicKey), utf8StringToArrayBuffer(groupId)));
+export const schnorrSignUtf8String = (privateKey: Uint8Array, publicKey: PublicKey<string>, string: string) => {
+    return RecryptApi.schnorrSign(privateKey, publicKeyToBytes(publicKey), utf8StringToArrayBuffer(string));
 };
 
 /**

--- a/src/frame/worker/index.ts
+++ b/src/frame/worker/index.ts
@@ -146,10 +146,12 @@ messenger.onMessage((data: RequestMessage, callback: (message: ResponseMessage, 
         case "GROUP_ADD_MEMBERS":
             return GroupCrypto.addMembersToGroup(
                 data.message.encryptedGroupKey,
+                data.message.groupPublicKey,
+                data.message.groupID,
                 data.message.userKeyList,
                 data.message.adminPrivateKey,
                 data.message.signingKeys
-            ).engage(errorHandler, (keyList) => callback({type: "GROUP_ADD_MEMBERS_RESPONSE", message: keyList}));
+            ).engage(errorHandler, (result) => callback({type: "GROUP_ADD_MEMBERS_RESPONSE", message: result}));
         default:
             //Force TS to tell us if we ever create a new request type that we don't handle here
             const exhaustiveCheck: never = data;

--- a/src/frame/worker/tests/GroupCrypto.test.ts
+++ b/src/frame/worker/tests/GroupCrypto.test.ts
@@ -139,9 +139,9 @@ describe("GroupCrypto", () => {
     describe("addMembersToGroup", () => {
         it("decrypts key and reencrypts it to the list of users provided", (done) => {
             const signature = new Uint8Array(32);
-            spyOn(Recrypt, "decryptPlaintext").and.returnValue(Future.of(["anything", "documentSymKey"]));
-            spyOn(Recrypt, "generateTransformKeyToList").and.returnValue(Future.of("keysForUser"));
-            spyOn(Recrypt, "generateAddMemberSignature").and.returnValue(Future.of(signature));
+            jest.spyOn(Recrypt, "decryptPlaintext").mockReturnValue(Future.of(["anything", "documentSymKey"]) as any);
+            jest.spyOn(Recrypt, "generateTransformKeyToList").mockReturnValue(Future.of("keysForUser") as any);
+            jest.spyOn(Recrypt, "schnorrSignUtf8String").mockReturnValue(signature as any);
 
             const groupPrivateKey = TestUtils.getTransformedSymmetricKey();
             const adminPrivateKey = new Uint8Array(20);
@@ -155,7 +155,7 @@ describe("GroupCrypto", () => {
                     expect(result).toEqual({transformKeyGrant: "keysForUser", signature});
                     expect(Recrypt.decryptPlaintext).toHaveBeenCalledWith(groupPrivateKey, adminPrivateKey);
                     expect(Recrypt.generateTransformKeyToList).toHaveBeenCalledWith("documentSymKey", userList, signingKeys);
-                    expect(Recrypt.generateAddMemberSignature).toHaveBeenCalledWith("documentSymKey", groupPublicKey, "groupID");
+                    expect(Recrypt.schnorrSignUtf8String).toHaveBeenCalledWith("documentSymKey", groupPublicKey, "groupID");
                     done();
                 }
             );

--- a/src/frame/worker/tests/GroupCrypto.test.ts
+++ b/src/frame/worker/tests/GroupCrypto.test.ts
@@ -155,11 +155,13 @@ describe("GroupCrypto", () => {
                     expect(result).toEqual({transformKeyGrant: "keysForUser", signature});
                     expect(Recrypt.decryptPlaintext).toHaveBeenCalledWith(groupPrivateKey, adminPrivateKey);
                     expect(Recrypt.generateTransformKeyToList).toHaveBeenCalledWith("documentSymKey", userList, signingKeys);
-                    expect(Recrypt.generateAddMemberSignature).toHaveBeenCalledWith("anything", groupPublicKey, "groupID");
+                    expect(Recrypt.generateAddMemberSignature).toHaveBeenCalledWith("documentSymKey", groupPublicKey, "groupID");
                     done();
                 }
             );
         });
+
+        // it("should generate a valid signature")
 
         it("maps errors to SDKError with specific error code", () => {
             spyOn(Recrypt, "decryptPlaintext").and.returnValue(Future.reject(new Error("plaintext decryption failed")));

--- a/src/frame/worker/tests/GroupCrypto.test.ts
+++ b/src/frame/worker/tests/GroupCrypto.test.ts
@@ -161,8 +161,6 @@ describe("GroupCrypto", () => {
             );
         });
 
-        // it("should generate a valid signature")
-
         it("maps errors to SDKError with specific error code", () => {
             spyOn(Recrypt, "decryptPlaintext").and.returnValue(Future.reject(new Error("plaintext decryption failed")));
 

--- a/src/frame/worker/tests/GroupCrypto.test.ts
+++ b/src/frame/worker/tests/GroupCrypto.test.ts
@@ -3,6 +3,7 @@ import * as Recrypt from "../crypto/recrypt/RecryptWasm";
 import Future from "futurejs";
 import * as TestUtils from "../../../tests/TestUtils";
 import {ErrorCodes} from "../../../Constants";
+import {publicKeyToBytes} from "../../../lib/Utils";
 
 describe("GroupCrypto", () => {
     describe("createGroup", () => {
@@ -155,7 +156,7 @@ describe("GroupCrypto", () => {
                     expect(result).toEqual({transformKeyGrant: "keysForUser", signature});
                     expect(Recrypt.decryptPlaintext).toHaveBeenCalledWith(groupPrivateKey, adminPrivateKey);
                     expect(Recrypt.generateTransformKeyToList).toHaveBeenCalledWith("documentSymKey", userList, signingKeys);
-                    expect(Recrypt.schnorrSignUtf8String).toHaveBeenCalledWith("documentSymKey", groupPublicKey, "groupID");
+                    expect(Recrypt.schnorrSignUtf8String).toHaveBeenCalledWith("documentSymKey", publicKeyToBytes(groupPublicKey), "groupID");
                     done();
                 }
             );

--- a/src/frame/worker/tests/index.test.ts
+++ b/src/frame/worker/tests/index.test.ts
@@ -327,6 +327,8 @@ describe("worker index", () => {
                     encryptedGroupKey: {
                         foo: "bar",
                     },
+                    groupPublicKey: new Uint8Array(32),
+                    groupID: "groupID",
                     userKeyList: ["32", "13"],
                     adminPrivateKey: new Uint8Array(32),
                     signingKeys: "signkeys",
@@ -336,7 +338,14 @@ describe("worker index", () => {
             messenger.onMessageCallback!(payload, (result: any) => {
                 expect(result.type).toEqual(expect.any(String));
                 expect(result.message).toEqual("added members");
-                expect(GroupCrypto.addMembersToGroup).toHaveBeenCalledWith({foo: "bar"}, ["32", "13"], new Uint8Array(32), "signkeys");
+                expect(GroupCrypto.addMembersToGroup).toHaveBeenCalledWith(
+                    {foo: "bar"},
+                    new Uint8Array(32),
+                    "groupID",
+                    ["32", "13"],
+                    new Uint8Array(32),
+                    "signkeys"
+                );
                 done();
             });
         });


### PR DESCRIPTION
	- added signature to the GroupAddMemberWorkerResponse worker message type,
	- added signature to the addMembers Endpoint,
	- changed the name of generateGroupTransformKeyToList to generateGroupTransformKeyToListAndSignature
	- added groupPublicKey and groupID to GroupAddMemberWorkerRequest
	- created a generateAddMemberSignature function in RecryptWasm