### PR TITLE
Force a safe ua-parser-js subdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
         "integrate": "yarn start",
         "nightwatch": "nightwatch"
     },
+    "resolutions": {
+        "**/ua-parser-js": "0.7.28"
+    },
     "dependencies": {
         "@ironcorelabs/recrypt-wasm-binding": "0.6.0",
         "@stablelib/ed25519": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7269,7 +7269,7 @@ typestrict@^1.0.0:
     tslint-microsoft-contrib "^5.0.3"
     tslint-sonarts "^1.8.0"
 
-ua-parser-js@^0.7.18:
+ua-parser-js@0.7.28, ua-parser-js@^0.7.18:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==


### PR DESCRIPTION
security fix, see faisalman/ua-parser-js#536
forces any dependency resolution of this as a sub dependency to use an uncompromised version
we should already not have been compromised, the lockfile had it set to an uncompromised version and hadn't been updated.
this repo in particular has it only as a devDependency sub-dep, anyone using `ironweb` through npm won't have it distributed.