### PR TITLE
Add device delete by id

### DIFF
--- a/integration/components/UserInfo.tsx
+++ b/integration/components/UserInfo.tsx
@@ -103,6 +103,17 @@ export default class UserInfo extends React.Component<Record<string, never>, Use
         }
     }
 
+    deleteDevice(deviceId: number) {
+        try {
+            IronWeb.user.deleteDevice(deviceId).then(() => {
+                logAction(`User's device successfully deleted.`);
+                this.listDevices();
+            });
+        } catch (e: any) {
+            logAction(`User device delete error: ${e.message}. Error Code: ${e.code}`, "error");
+        }
+    }
+
     listDevices() {
         try {
             this.setState({loading: true});
@@ -198,15 +209,16 @@ export default class UserInfo extends React.Component<Record<string, never>, Use
                     {this.state.deviceList
                         .map((device, index) => (
                             <ul key={index}>
-                                <li>Name: {device.name}</li>
+                                <li>Name: {String(device.name)}</li>
                                 <li>ID: {device.id}</li>
-                                <li>Current Device: {device.isCurrentDevice}</li>
+                                <li>Current Device: {String(device.isCurrentDevice)}</li>
                                 <li>Public Signing Key: {device.publicSigningKey}</li>
                                 <li>Created: {device.created}</li>
                                 <li>Updated: {device.updated}</li>
+                                <RaisedButton onClick={() => this.deleteDevice(device.id)}>Delete Device</RaisedButton>
                             </ul>
                         ))
-                        .flatMap((e, index) => [<hr key={index}/>, e])
+                        .flatMap((e, index) => [<hr key={index} />, e])
                         .slice(1)}
                 </div>
             );

--- a/integration/components/UserInfo.tsx
+++ b/integration/components/UserInfo.tsx
@@ -94,8 +94,8 @@ export default class UserInfo extends React.Component<Record<string, never>, Use
 
     clearDeviceAndSigningKeys() {
         try {
-            IronWeb.user.deauthorizeDevice().then((result) => {
-                logAction(`User device successfully deauthorized. Deleted transform key: ${result.transformKeyDeleted}`);
+            IronWeb.user.deleteDevice().then(() => {
+                logAction(`User's device successfully deauthorized.`);
                 window.location.reload();
             });
         } catch (e: any) {

--- a/ironweb.d.ts
+++ b/ironweb.d.ts
@@ -175,7 +175,11 @@ export interface BlindSearchIndex {
  * SDK Namespaces
  */
 export interface User {
+    /**
+     * Deprecated, use deleteDevice() with no argument to deauthorize the current device instead.
+     */
     deauthorizeDevice(): Promise<{transformKeyDeleted: boolean}>;
+    deleteDevice(deviceId?: number): Promise<number>;
     listDevices(): Promise<UserDeviceListResponse>;
     changePasscode(currentPasscode: string, newPasscode: string): Promise<void>;
     rotateMasterKey(passcode: string): Promise<void>;

--- a/src/FrameMessageTypes.d.ts
+++ b/src/FrameMessageTypes.d.ts
@@ -425,13 +425,13 @@ export interface ChangeUserPasscodeResponse {
     type: "CHANGE_USER_PASSCODE_RESPONSE";
     message: null;
 }
-export interface DeauthorizeDevice {
-    type: "DEAUTHORIZE_DEVICE";
-    message: null;
+export interface DeleteDevice {
+    type: "DELETE_DEVICE";
+    message: number | undefined;
 }
-export interface DeauthorizeDeviceResponse {
-    type: "DEAUTHORIZE_DEVICE_RESPONSE";
-    message: boolean;
+export interface DeleteDeviceResponse {
+    type: "DELETE_DEVICE_RESPONSE";
+    message: number;
 }
 export interface ListDevices {
     type: "LIST_DEVICES";
@@ -535,8 +535,8 @@ export type RequestMessage =
     | GroupRemoveSelfAsMemberRequest
     | GroupDeleteRequest
     | ChangeUserPasscode
-    | DeauthorizeDevice
     | ListDevices
+    | DeleteDevice
     | DocumentUnmanagedDecryptRequest
     | DocumentUnmanagedEncryptRequest
     | BlindSearchIndexCreate
@@ -565,8 +565,8 @@ export type ResponseMessage =
     | ChangeUserPasscodeResponse
     | CreateUserResponse
     | CreateDetachedUserDeviceResponse
-    | DeauthorizeDeviceResponse
     | ListDevicesResponse
+    | DeleteDeviceResponse
     | GroupListResponse
     | GroupGetResponse
     | GroupCreateResponse

--- a/src/frame/endpoints/UserApiEndpoints.ts
+++ b/src/frame/endpoints/UserApiEndpoints.ts
@@ -178,6 +178,20 @@ const deleteCurrentDevice = (userID: string): RequestMeta => ({
 });
 
 /**
+ * Delete the user`s device by ID.
+ */
+ const deleteDevice = (userID: string, deviceId: number): RequestMeta => ({
+    url: `users/${encodeURIComponent(userID)}/devices/${encodeURIComponent(deviceId)}`,
+    options: {
+        method: "DELETE",
+        headers: {
+            "Content-Type": "application/json",
+        },
+    },
+    errorCode: ErrorCodes.USER_DEVICE_DELETE_REQUEST_FAILURE,
+});
+
+/**
  * Update a users status and/or their escrowed private key.
  * @param {string}                 userID         ID of user to update
  * @param {PrivateKey<Uint8Array>} userPrivateKey Users encrypted private key to escrow
@@ -319,6 +333,15 @@ export default {
     callUserCurrentDeviceDelete(): Future<SDKError, {id: number}> {
         const {id} = ApiState.user();
         const {url, options, errorCode} = deleteCurrentDevice(id);
+        return makeAuthorizedApiRequest(url, errorCode, options);
+    },
+
+    /**
+     * Delete the user's device by Id.
+     */
+    callUserDeviceDelete(deviceId: number): Future<SDKError, {id: number}> {
+        const {id: userId} = ApiState.user();
+        const {url, options, errorCode} = deleteDevice(userId, deviceId);
         return makeAuthorizedApiRequest(url, errorCode, options);
     },
 

--- a/src/frame/index.ts
+++ b/src/frame/index.ts
@@ -71,8 +71,8 @@ function onParentPortMessage(data: RequestMessage, callback: (message: ResponseM
             return Init.createDetachedUserDevice(data.message.jwtToken, data.message.passcode).engage(errorHandler, (result) =>
                 callback({type: "CREATE_DETATCHED_USER_DEVICE_RESPONSE", message: result})
             );
-        case "DEAUTHORIZE_DEVICE":
-            return UserApi.deauthorizeDevice().engage(errorHandler, (result) => callback({type: "DEAUTHORIZE_DEVICE_RESPONSE", message: result}));
+        case "DELETE_DEVICE":
+            return UserApi.deleteDevice(data.message).engage(errorHandler, (result) => callback({type: "DELETE_DEVICE_RESPONSE", message: result}));
         case "CHANGE_USER_PASSCODE":
             return UserApi.changeUsersPasscode(data.message.currentPasscode, data.message.newPasscode).engage(errorHandler, () =>
                 callback({type: "CHANGE_USER_PASSCODE_RESPONSE", message: null})

--- a/src/frame/sdk/UserApi.ts
+++ b/src/frame/sdk/UserApi.ts
@@ -63,19 +63,14 @@ export function changeUsersPasscode(currentPasscode: string, newPasscode: string
 export const deleteDevice = (deviceId?: number) => {
     // if the id is undefined we're deleting the current device and need to do some more work
     if (deviceId === undefined) {
-        console.log("good side");
         return (
             UserApiEndpoints.callUserCurrentDeviceDelete()
                 //If the delete request fails, we don't want to fail the Promise the caller gets because we'll still be able to delete
                 //their device private key from local storage. So mock out a fake ID here that we can use to decision off of.
-                .handleWith((e) => {
-                    console.log(`handling: ${e}`);
-                    return Future.of({id: -1});
-                })
+                .handleWith(() => Future.of({id: -1}))
                 .map((deleteResponse) => {
                     const user = ApiState.user();
 
-                    console.log(user);
                     const {id, segmentId} = user;
                     clearDeviceAndSigningKeys(id, segmentId);
                     ApiState.clearCurrentUser();
@@ -83,7 +78,6 @@ export const deleteDevice = (deviceId?: number) => {
                 })
         );
     } else {
-        console.log("bad side");
         return UserApiEndpoints.callUserDeviceDelete(deviceId).map((r) => r.id);
     }
 };

--- a/src/frame/tests/index.test.ts
+++ b/src/frame/tests/index.test.ts
@@ -532,19 +532,19 @@ describe("frame index", () => {
     });
 
     describe("onMessage user tests", () => {
-        it("DEAUTHORIZE_DEVICE", (done) => {
-            jest.spyOn(UserApi, "deauthorizeDevice").mockReturnValue(Future.of<any>("deauthDevice"));
-            const payload: MT.DeauthorizeDevice = {
-                type: "DEAUTHORIZE_DEVICE",
-                message: null,
+        it("DELETE_DEVICE", (done) => {
+            jest.spyOn(UserApi, "deleteDevice").mockReturnValue(Future.of<any>(10));
+            const payload: MT.DeleteDevice = {
+                type: "DELETE_DEVICE",
+                message: undefined,
             };
 
             messenger.onMessageCallback(payload, (result: any) => {
                 expect(result).toEqual({
-                    type: "DEAUTHORIZE_DEVICE_RESPONSE",
-                    message: "deauthDevice",
+                    type: "DELETE_DEVICE_RESPONSE",
+                    message: 10,
                 });
-                expect(UserApi.deauthorizeDevice).toHaveBeenCalledWith();
+                expect(UserApi.deleteDevice).toHaveBeenCalledWith(undefined);
                 done();
             });
         });

--- a/src/shim/sdk/UserSDK.ts
+++ b/src/shim/sdk/UserSDK.ts
@@ -45,7 +45,6 @@ export const deauthorizeDevice = () => deleteDevice().then((deletedDevice) => ({
  * This method should usually be called whenever the current user logs out of your application or you're aware a device of their's shouldn't have access.
  * @param {number | undefined} deviceId The device id to delete. If undefined, the current device will be deleted and local storage will be cleared.
  */
-// TODO: detect if deviceId is the same as the currently operating device and set deletingCurrentDevice to true
 export const deleteDevice = (deviceId?: number) => {
     checkSDKInitialized();
     const deletingCurrentDevice = deviceId === undefined;

--- a/src/shim/sdk/UserSDK.ts
+++ b/src/shim/sdk/UserSDK.ts
@@ -50,7 +50,7 @@ export const deleteDevice = (deviceId?: number) => {
     const deletingCurrentDevice = deviceId === undefined;
     const payload: MT.DeleteDevice = {
         type: "DELETE_DEVICE",
-        message: deletingCurrentDevice ? undefined : deviceId,
+        message: deviceId,
     };
     // If current device, clear the local symmetric key from local storage, then send a request to clear the frames local storage.
     // Once that's complete clear the SDK init flag so that the user has to rerun init before the SDK methods will work again.

--- a/src/shim/sdk/UserSDK.ts
+++ b/src/shim/sdk/UserSDK.ts
@@ -34,30 +34,44 @@ export function rotateMasterKey(passcode: string) {
 }
 
 /**
+ * @deprecated Use deleteDevice with no arguments to get the same behavior.
  * Clears local device keys from the current browser instance. This will require the user to enter their passcode the next time they want to use this browser on this machine.
  * This method should usually be called whenever the current user logs out of your application.
  */
-export function deauthorizeDevice() {
+export const deauthorizeDevice = () => deleteDevice().then((deletedDevice) => ({transformKeyDeleted: deletedDevice > 0}));
+
+/**
+ * Deletes a device. If deleting the current device, the user will have to enter their passcode the next time they want to use this browser on this machine.
+ * This method should usually be called whenever the current user logs out of your application or you're aware a device of their's shouldn't have access.
+ * @param {number | undefined} deviceId The device id to delete. If undefined, the current device will be deleted and local storage will be cleared.
+ */
+// TODO: detect if deviceId is the same as the currently operating device and set deletingCurrentDevice to true
+export const deleteDevice = (deviceId?: number) => {
     checkSDKInitialized();
-    const payload: MT.DeauthorizeDevice = {
-        type: "DEAUTHORIZE_DEVICE",
-        message: null,
+    const deletingCurrentDevice = deviceId === undefined;
+    const payload: MT.DeleteDevice = {
+        type: "DELETE_DEVICE",
+        message: deletingCurrentDevice ? undefined : deviceId,
     };
-    //Clear the local symmetric key from local storage, then send a request to clear the frames local storage. Once that's complete clear the SDK init flag
-    //so that the user has to rerun init before the SDK methods will work again.
-    clearParentWindowSymmetricKey();
-    return FrameMediator.sendMessage<MT.DeauthorizeDeviceResponse>(payload)
+    // If current device, clear the local symmetric key from local storage, then send a request to clear the frames local storage.
+    // Once that's complete clear the SDK init flag so that the user has to rerun init before the SDK methods will work again.
+    if (deletingCurrentDevice) {
+        clearParentWindowSymmetricKey();
+    }
+    return FrameMediator.sendMessage<MT.DeleteDeviceResponse>(payload)
         .map(({message}) => {
-            clearSDKInitialized();
-            return {transformKeyDeleted: message};
+            if (deletingCurrentDevice) {
+                clearSDKInitialized();
+            }
+            return message;
         })
         .toPromise();
-}
+};
 
 /**
  * Lists all the devices for the currently logged in user.
  */
-export function listDevices() {
+export const listDevices = () => {
     checkSDKInitialized();
     const payload: MT.ListDevices = {
         type: "LIST_DEVICES",
@@ -66,4 +80,4 @@ export function listDevices() {
     return FrameMediator.sendMessage<MT.ListDevicesResponse>(payload)
         .map(({message: result}) => result)
         .toPromise();
-}
+};

--- a/src/shim/sdk/tests/UserSDK.test.ts
+++ b/src/shim/sdk/tests/UserSDK.test.ts
@@ -5,7 +5,7 @@ import * as ShimUtils from "../../ShimUtils";
 
 describe("UserSDK", () => {
     beforeEach(() => {
-        jest.spyOn(FrameMediator, "sendMessage").mockReturnValue(Future.of<any>({message: "messageResponse"}));
+        jest.spyOn(FrameMediator, "sendMessage").mockReturnValue(Future.of<any>({message: 10}));
     });
 
     afterEach(() => {
@@ -24,10 +24,10 @@ describe("UserSDK", () => {
                 jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
                 UserSDK.deauthorizeDevice()
                     .then((result: any) => {
-                        expect(result).toEqual({transformKeyDeleted: "messageResponse"});
+                        expect(result).toEqual({transformKeyDeleted: true});
                         expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
-                            type: "DEAUTHORIZE_DEVICE",
-                            message: null,
+                            type: "DELETE_DEVICE",
+                            message: undefined,
                         });
                         expect(ShimUtils.clearParentWindowSymmetricKey).toHaveBeenCalledWith();
                         done();
@@ -102,6 +102,45 @@ describe("UserSDK", () => {
                     })
                     .catch((e) => done(e));
             });
+        });
+    });
+
+    describe("deleteDevice", () => {
+        it("throws if SDK has not yet been initialized", () => {
+            ShimUtils.clearSDKInitialized();
+            expect(() => UserSDK.deleteDevice()).toThrow();
+        });
+
+        it("sends deauth request type to frame if device is defaulted to the current one", (done) => {
+            ShimUtils.setSDKInitialized();
+            jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
+            UserSDK.deleteDevice()
+                .then((result: any) => {
+                    expect(result).toEqual(10);
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DELETE_DEVICE",
+                        message: undefined,
+                    });
+                    expect(ShimUtils.clearParentWindowSymmetricKey).toHaveBeenCalledWith();
+                    done();
+                })
+                .catch((e) => done(e));
+        });
+
+        it("doesn't send deauth request type to frame if a device is passed", (done) => {
+            ShimUtils.setSDKInitialized();
+            jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
+            UserSDK.deleteDevice(10)
+                .then((result: any) => {
+                    expect(result).toEqual(10);
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DELETE_DEVICE",
+                        message: 10,
+                    });
+                    expect(ShimUtils.clearParentWindowSymmetricKey).not.toHaveBeenCalled();
+                    done();
+                })
+                .catch((e) => done(e));
         });
     });
 });

--- a/src/shim/sdk/tests/UserSDK.test.ts
+++ b/src/shim/sdk/tests/UserSDK.test.ts
@@ -19,7 +19,7 @@ describe("UserSDK", () => {
                 expect(() => UserSDK.deauthorizeDevice()).toThrow();
             });
 
-            it("sends deauth request type to frame", (done) => {
+            it("sends delete request type to frame", (done) => {
                 ShimUtils.setSDKInitialized();
                 jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
                 UserSDK.deauthorizeDevice()
@@ -93,7 +93,7 @@ describe("UserSDK", () => {
                 ShimUtils.setSDKInitialized();
                 UserSDK.listDevices()
                     .then((result: any) => {
-                        expect(result).toEqual("messageResponse");
+                        expect(result).toEqual(10);
                         expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
                             type: "LIST_DEVICES",
                             message: null,
@@ -111,7 +111,7 @@ describe("UserSDK", () => {
             expect(() => UserSDK.deleteDevice()).toThrow();
         });
 
-        it("sends deauth request type to frame if device is defaulted to the current one", (done) => {
+        it("sends delete request type to frame if device is defaulted to the current one", (done) => {
             ShimUtils.setSDKInitialized();
             jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
             UserSDK.deleteDevice()
@@ -127,7 +127,7 @@ describe("UserSDK", () => {
                 .catch((e) => done(e));
         });
 
-        it("doesn't send deauth request type to frame if a device is passed", (done) => {
+        it("doesn't send delete request type to frame if a device is passed", (done) => {
             ShimUtils.setSDKInitialized();
             jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
             UserSDK.deleteDevice(10)


### PR DESCRIPTION
This also deprecates `deauthorizeDevice`, since `deleteDevice` with no device id argument accomplishes the same goal.