### PR TITLE
Add deleteDeviceByPublicSigningKeyWithJwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The IronWeb SDK NPM releases follow standard [Semantic Versioning](https://semve
 
 **Note:** The patch versions of the IronWeb SDK will not be sequential and might jump by multiple numbers between sequential releases.
 
+## v4.2.1
+- added `deleteDeviceByPublicSigningKeyWithJwt` to the User SDK. This allows someone with access to a JWT for a user to delete a device for that user without initializing the SDK (and creating a new browser device).
+
 ## v4.1.1
 - added `listDevices()` to the User SDK. This lists all devices for the currently logged in user.
 - added `deleteDevice(deviceId?: number)` to the User SDK. This deletes a user's device by ID, and if passed no ID deletes the current device and clears its keys from browser storage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The IronWeb SDK NPM releases follow standard [Semantic Versioning](https://semve
 **Note:** The patch versions of the IronWeb SDK will not be sequential and might jump by multiple numbers between sequential releases.
 
 ## v4.2.1
-- added `deleteDeviceByPublicSigningKeyWithJwt` to the User SDK. This allows someone with access to a JWT for a user to delete a device for that user without initializing the SDK (and creating a new browser device).
+- added `deleteDeviceByPublicSigningKeyWithJwt` to the SDK. This allows someone with access to a JWT for a user to delete a device for that user without initializing the SDK (and creating a new browser device).
 
 ## v4.1.1
 - added `listDevices()` to the User SDK. This lists all devices for the currently logged in user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The IronWeb SDK NPM releases follow standard [Semantic Versioning](https://semve
 **Note:** The patch versions of the IronWeb SDK will not be sequential and might jump by multiple numbers between sequential releases.
 
 ## v4.2.1
-- added `deleteDeviceByPublicSigningKeyWithJwt` to the SDK. This allows someone with access to a JWT for a user to delete a device for that user without initializing the SDK (and creating a new browser device).
+- added `deleteDeviceByPublicSigningKey` to the SDK. This allows someone with access to a JWT for a user to delete a device for that user without initializing the SDK (and creating a new browser device).
 
 ## v4.1.1
 - added `listDevices()` to the User SDK. This lists all devices for the currently logged in user.

--- a/integration/components/InitializeApi.tsx
+++ b/integration/components/InitializeApi.tsx
@@ -147,8 +147,7 @@ export default class InitializeApi extends React.Component<InitializeApiProps, I
 
     deleteDevice = () => {
         logAction(`Deleting a device by signing key '${this.state.devicePublicSigningKey}' manually...`);
-        IronWeb.user
-            .deleteDeviceByPublicSigningKeyWithJwt(this.generateJWT, this.state.devicePublicSigningKey)
+        IronWeb.deleteDeviceByPublicSigningKey(this.generateJWT, this.state.devicePublicSigningKey)
             .then((res) => {
                 logAction(`User device manually deleted with signing key ${this.state.devicePublicSigningKey} and device ID ${res}.`, "success");
                 this.setState({devicePublicSigningKey: ""});

--- a/integration/components/InitializeApi.tsx
+++ b/integration/components/InitializeApi.tsx
@@ -12,6 +12,7 @@ interface InitializeApiProps {
 interface InitializeApiState {
     showSetPasscode: boolean;
     passcode: string;
+    devicePublicSigningKey: string;
 }
 
 declare global {
@@ -37,6 +38,7 @@ export default class InitializeApi extends React.Component<InitializeApiProps, I
         this.state = {
             showSetPasscode: false,
             passcode: "",
+            devicePublicSigningKey: "",
         };
     }
 
@@ -143,6 +145,17 @@ export default class InitializeApi extends React.Component<InitializeApiProps, I
             .catch((e) => logAction(`Failed to create user device: '${e.message}'`, "error"));
     };
 
+    deleteDevice = () => {
+        logAction(`Deleting a device by signing key '${this.state.devicePublicSigningKey}' manually...`);
+        IronWeb.user
+            .deleteDeviceByPublicSigningKeyWithJwt(this.generateJWT, this.state.devicePublicSigningKey)
+            .then((res) => {
+                logAction(`User device manually deleted with signing key ${this.state.devicePublicSigningKey} and device ID ${res}.`, "success");
+                this.setState({devicePublicSigningKey: ""});
+            })
+            .catch((e) => logAction(`Failed to delete user device: '${e.message}'`, "error"));
+    };
+
     getInitUIElement() {
         if (this.state.showSetPasscode) {
             return [
@@ -166,6 +179,20 @@ export default class InitializeApi extends React.Component<InitializeApiProps, I
                         <br />
                         <br />
                         <RaisedButton className="initialize-create-device" secondary onClick={this.createDevice} label="Create Device" />
+                        <br />
+                        <br />
+                        <TextField
+                            key="deviceSigningKey"
+                            type="text"
+                            hintText="Device Signing Key"
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                this.setState({
+                                    devicePublicSigningKey: e.currentTarget.value,
+                                });
+                            }}
+                            value={this.state.devicePublicSigningKey}
+                        />
+                        <RaisedButton secondary onClick={this.deleteDevice} label="Delete Device" />
                     </div>
                 </Tab>
             </Tabs>

--- a/ironweb.d.ts
+++ b/ironweb.d.ts
@@ -181,6 +181,7 @@ export interface User {
     deauthorizeDevice(): Promise<{transformKeyDeleted: boolean}>;
     deleteDevice(deviceId?: number): Promise<number>;
     deleteDeviceByPublicSigningKey(publicSigningKey: Base64String): Promise<number>;
+    deleteDeviceByPublicSigningKeyWithJwt(jwtCallback: JWTCallback, publicSigningKey: Base64String): Promise<number>;
     listDevices(): Promise<UserDeviceListResponse>;
     changePasscode(currentPasscode: string, newPasscode: string): Promise<void>;
     rotateMasterKey(passcode: string): Promise<void>;

--- a/ironweb.d.ts
+++ b/ironweb.d.ts
@@ -181,7 +181,6 @@ export interface User {
     deauthorizeDevice(): Promise<{transformKeyDeleted: boolean}>;
     deleteDevice(deviceId?: number): Promise<number>;
     deleteDeviceByPublicSigningKey(publicSigningKey: Base64String): Promise<number>;
-    deleteDeviceByPublicSigningKeyWithJwt(jwtCallback: JWTCallback, publicSigningKey: Base64String): Promise<number>;
     listDevices(): Promise<UserDeviceListResponse>;
     changePasscode(currentPasscode: string, newPasscode: string): Promise<void>;
     rotateMasterKey(passcode: string): Promise<void>;
@@ -335,3 +334,4 @@ export function initialize(jwtCallback: JWTCallback, passcodeCallback: PasscodeC
 export function createNewUser(jwtCallback: JWTCallback, passcode: string, options?: UserCreateOptions): Promise<UserCreateResponse>;
 export function createNewDeviceKeys(jwtCallback: JWTCallback, passcode: string): Promise<DeviceKeys>;
 export function isInitialized(): boolean;
+export function deleteDeviceByPublicSigningKey(jwtCallback: JWTCallback, publicSigningKey: Base64String): Promise<number>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "license": "AGPL-3.0-only",
-    "version": "4.1.1",
+    "version": "4.2.0",
     "scripts": {
         "cleanTest": "find dist -type d -name tests -prune -exec rm -rf {} \\;",
         "lint": "eslint . --ext .ts,.tsx",

--- a/src/FrameMessageTypes.d.ts
+++ b/src/FrameMessageTypes.d.ts
@@ -433,6 +433,13 @@ export interface DeleteDeviceBySigningKey {
     type: "DELETE_DEVICE_BY_SIGNING_KEY";
     message: Base64String;
 }
+export interface DeleteDeviceBySigningKeyJwt {
+    type: "DELETE_DEVICE_BY_SIGNING_KEY_JWT";
+    message: {
+        jwtToken: string;
+        publicSigningKey: Base64String;
+    };
+}
 export interface DeleteDeviceResponse {
     type: "DELETE_DEVICE_RESPONSE";
     message: number;
@@ -542,6 +549,7 @@ export type RequestMessage =
     | ListDevices
     | DeleteDevice
     | DeleteDeviceBySigningKey
+    | DeleteDeviceBySigningKeyJwt
     | DocumentUnmanagedDecryptRequest
     | DocumentUnmanagedEncryptRequest
     | BlindSearchIndexCreate

--- a/src/frame/endpoints/UserApiEndpoints.ts
+++ b/src/frame/endpoints/UserApiEndpoints.ts
@@ -206,6 +206,20 @@ const deleteDeviceBySigningKey = (userID: string, publicSigningKey: Base64String
 });
 
 /**
+ * Delete the user`s device by public signing key.
+ */
+const deleteDeviceBySigningKeyWithJwt = (publicSigningKey: Base64String): RequestMeta => ({
+    url: `users/devices/${encodeURIComponent(publicSigningKey)}`,
+    options: {
+        method: "DELETE",
+        headers: {
+            "Content-Type": "application/json",
+        },
+    },
+    errorCode: ErrorCodes.USER_DEVICE_DELETE_REQUEST_FAILURE,
+});
+
+/**
  * Update a users status and/or their escrowed private key.
  * @param {string}                 userID         ID of user to update
  * @param {PrivateKey<Uint8Array>} userPrivateKey Users encrypted private key to escrow
@@ -366,6 +380,14 @@ export default {
         const {id: userId} = ApiState.user();
         const {url, options, errorCode} = deleteDeviceBySigningKey(userId, publicSigningKey);
         return makeAuthorizedApiRequest(url, errorCode, options);
+    },
+
+    /**
+     * Delete the user's device by public signing key, using JWT auth.
+     */
+    callUserDeviceDeleteBySigningKeyWithJwt(jwtToken: string, publicSigningKey: Base64String): Future<SDKError, {id: number}> {
+        const {url, options, errorCode} = deleteDeviceBySigningKeyWithJwt(publicSigningKey);
+        return makeJwtApiRequest(url, errorCode, options, jwtToken);
     },
 
     /**

--- a/src/frame/endpoints/tests/UserApiEndpoints.test.ts
+++ b/src/frame/endpoints/tests/UserApiEndpoints.test.ts
@@ -373,6 +373,26 @@ describe("UserApiEndpoints", () => {
         });
     });
 
+    describe("callUserDeviceDeleteBySigningKeyWithJwt", () => {
+        it("calls API and returns data as expected", () => {
+            (ApiRequest.makeJwtApiRequest as unknown as jest.SpyInstance).mockReturnValue(
+                Future.of<any>({
+                    id: 7,
+                })
+            );
+
+            UserApiEndpoints.callUserDeviceDeleteBySigningKeyWithJwt("jwt", "signingKey" as unknown as Base64String).engage(
+                (e) => {
+                    throw e;
+                },
+                (deletedId: any) => {
+                    expect(deletedId).toEqual({id: 7});
+                    expect(ApiRequest.makeJwtApiRequest).toHaveBeenCalledWith("users/devices/signingKey", expect.any(Number), expect.any(Object), "jwt");
+                }
+            );
+        });
+    });
+
     describe("callUserKeyListApi", () => {
         it("calls API and returns mapped response data", () => {
             (ApiRequest.makeAuthorizedApiRequest as unknown as jest.SpyInstance).mockReturnValue(

--- a/src/frame/index.ts
+++ b/src/frame/index.ts
@@ -75,6 +75,10 @@ function onParentPortMessage(data: RequestMessage, callback: (message: ResponseM
             return UserApi.deleteDevice(data.message).engage(errorHandler, (result) => callback({type: "DELETE_DEVICE_RESPONSE", message: result}));
         case "DELETE_DEVICE_BY_SIGNING_KEY":
             return UserApi.deleteDeviceBySigningKey(data.message).engage(errorHandler, (result) => callback({type: "DELETE_DEVICE_RESPONSE", message: result}));
+        case "DELETE_DEVICE_BY_SIGNING_KEY_JWT":
+            return UserApi.deleteDeviceBySigningKeyWithJwt(data.message.jwtToken, data.message.publicSigningKey).engage(errorHandler, (result) =>
+                callback({type: "DELETE_DEVICE_RESPONSE", message: result})
+            );
         case "CHANGE_USER_PASSCODE":
             return UserApi.changeUsersPasscode(data.message.currentPasscode, data.message.newPasscode).engage(errorHandler, () =>
                 callback({type: "CHANGE_USER_PASSCODE_RESPONSE", message: null})

--- a/src/frame/sdk/UserApi.ts
+++ b/src/frame/sdk/UserApi.ts
@@ -89,6 +89,12 @@ export const deleteDeviceBySigningKey = (publicSigningKey: Base64String) =>
     UserApiEndpoints.callUserDeviceDeleteBySigningKey(publicSigningKey).map((r) => r.id);
 
 /**
+* Delete a device from the DB given the public signing key of the device. Uses JWT auth.
+*/
+export const deleteDeviceBySigningKeyWithJwt = (jwtToken: string, publicSigningKey: Base64String) =>
+    UserApiEndpoints.callUserDeviceDeleteBySigningKeyWithJwt(jwtToken, publicSigningKey).map((r) => r.id);
+
+/**
  * Makes a request to list the devices for the currently logged in user.
  */
 export const listDevices = () => UserApiEndpoints.callUserListDevices();

--- a/src/frame/sdk/tests/UserApi.test.ts
+++ b/src/frame/sdk/tests/UserApi.test.ts
@@ -135,4 +135,17 @@ describe("UserApi", () => {
             );
         });
     });
+
+    describe("deleteDeviceBySigningKeyWithJwt", () => {
+        it("calls the correct API", async () => {
+            jest.spyOn(UserApiEndpoints, "callUserDeviceDeleteBySigningKeyWithJwt").mockReturnValue(Future.of<any>({id: 33}));
+            ApiState.clearCurrentUser();
+            expect(ApiState.user()).toBeUndefined();
+            const result = await UserApi.deleteDeviceBySigningKeyWithJwt("jwt", "signingKey");
+
+            expect(UserApiEndpoints.callUserDeviceDeleteBySigningKeyWithJwt).toHaveBeenCalledWith("jwt", "signingKey");
+            expect(result).toBe(33);
+            expect(ApiState.user()).toBeUndefined();
+        });
+    });
 });

--- a/src/shim/Initialize.ts
+++ b/src/shim/Initialize.ts
@@ -23,7 +23,7 @@ let userJWTCallback: JWTCallbackToPromise;
  * Retrieve the users JWT token and validate the result
  * @param  {CallbackToPromise} jwtCallback Method that can be used to retrieve the JWT
  */
-function getJWT(jwtCallback: JWTCallbackToPromise) {
+export function getJWT(jwtCallback: JWTCallbackToPromise): Future<Error, string> {
     return Future.tryP(() => {
         const jwtPromise = jwtCallback();
         if (jwtPromise && typeof jwtPromise.then === "function") {

--- a/src/shim/Initialize.ts
+++ b/src/shim/Initialize.ts
@@ -7,6 +7,8 @@ import {
     CreateUserAndDeviceRequest,
     CreateUserRequest,
     CreateUserResponse,
+    DeleteDeviceBySigningKeyJwt,
+    DeleteDeviceResponse,
     GenerateNewDeviceKeysRequest,
     InitApiPasscodeResponse,
     InitApiRequest,
@@ -23,7 +25,7 @@ let userJWTCallback: JWTCallbackToPromise;
  * Retrieve the users JWT token and validate the result
  * @param  {CallbackToPromise} jwtCallback Method that can be used to retrieve the JWT
  */
-export function getJWT(jwtCallback: JWTCallbackToPromise): Future<Error, string> {
+function getJWT(jwtCallback: JWTCallbackToPromise): Future<Error, string> {
     return Future.tryP(() => {
         const jwtPromise = jwtCallback();
         if (jwtPromise && typeof jwtPromise.then === "function") {
@@ -151,3 +153,21 @@ export function initialize(jwtCallback: JWTCallbackToPromise, passcodeCallback: 
         })
         .toPromise();
 }
+
+/**
+ * Deletes a device by its public signing key. Uses JWT auth, so it doesn't require an initialized SDK.
+ * @param {Base64String} publicSigningKey The public signing key of the device to delete.
+ */
+export const deleteDeviceByPublicSigningKey = (jwtCallback: JWTCallbackToPromise, publicSigningKey: Base64String): Promise<number> =>
+    getJWT(jwtCallback)
+        .flatMap((jwtToken) => {
+            const payload: DeleteDeviceBySigningKeyJwt = {
+                type: "DELETE_DEVICE_BY_SIGNING_KEY_JWT",
+                message: {
+                    jwtToken,
+                    publicSigningKey,
+                },
+            };
+            return FrameMediator.sendMessage<DeleteDeviceResponse>(payload).map(({message}) => message);
+        })
+        .toPromise();

--- a/src/shim/index.ts
+++ b/src/shim/index.ts
@@ -3,6 +3,7 @@ import {ErrorCodes} from "../Constants";
 import SDKError from "../lib/SDKError";
 import * as Init from "./Initialize";
 import {checkSDKInitialized} from "./ShimUtils";
+export {deleteDeviceByPublicSigningKey} from "./Initialize";
 
 /**
  * Checks bowser functionality to ensure random number generation is supported.

--- a/src/shim/sdk/UserSDK.ts
+++ b/src/shim/sdk/UserSDK.ts
@@ -1,6 +1,8 @@
 import {clearParentWindowSymmetricKey, checkSDKInitialized, clearSDKInitialized} from "../ShimUtils";
 import * as FrameMediator from "../FrameMediator";
 import * as MT from "../../FrameMessageTypes";
+import {getJWT} from "../Initialize";
+import {JWTCallback} from "ironweb";
 
 /**
  * Update an existing users passcode that is used to escrow their private key. The returned Promise will resolve successfully upon passcode change or
@@ -81,6 +83,24 @@ export const deleteDeviceByPublicSigningKey = (publicSigningKey: Base64String) =
         .map(({message}) => message)
         .toPromise();
 };
+
+/**
+ * Deletes a device by its public signing key. Uses JWT auth, so it doesn't require an initialized SDK.
+ * @param {Base64String} publicSigningKey The public signing key of the device to delete.
+ */
+export const deleteDeviceByPublicSigningKeyWithJwt = (jwtCallback: JWTCallback, publicSigningKey: Base64String): Promise<number> =>
+    getJWT(jwtCallback)
+        .flatMap((jwtToken) => {
+            const payload: MT.DeleteDeviceBySigningKeyJwt = {
+                type: "DELETE_DEVICE_BY_SIGNING_KEY_JWT",
+                message: {
+                    jwtToken,
+                    publicSigningKey,
+                },
+            };
+            return FrameMediator.sendMessage<MT.DeleteDeviceResponse>(payload).map(({message}) => message);
+        })
+        .toPromise();
 
 /**
  * Lists all the devices for the currently logged in user.

--- a/src/shim/sdk/UserSDK.ts
+++ b/src/shim/sdk/UserSDK.ts
@@ -1,8 +1,6 @@
 import {clearParentWindowSymmetricKey, checkSDKInitialized, clearSDKInitialized} from "../ShimUtils";
 import * as FrameMediator from "../FrameMediator";
 import * as MT from "../../FrameMessageTypes";
-import {getJWT} from "../Initialize";
-import {JWTCallback} from "ironweb";
 
 /**
  * Update an existing users passcode that is used to escrow their private key. The returned Promise will resolve successfully upon passcode change or
@@ -20,6 +18,7 @@ export function changePasscode(currentPasscode: string, newPasscode: string) {
         .map(() => undefined)
         .toPromise();
 }
+
 /**
  * Rotates the user current private key.
  * @param {string} passcode The users current passcode
@@ -83,24 +82,6 @@ export const deleteDeviceByPublicSigningKey = (publicSigningKey: Base64String) =
         .map(({message}) => message)
         .toPromise();
 };
-
-/**
- * Deletes a device by its public signing key. Uses JWT auth, so it doesn't require an initialized SDK.
- * @param {Base64String} publicSigningKey The public signing key of the device to delete.
- */
-export const deleteDeviceByPublicSigningKeyWithJwt = (jwtCallback: JWTCallback, publicSigningKey: Base64String): Promise<number> =>
-    getJWT(jwtCallback)
-        .flatMap((jwtToken) => {
-            const payload: MT.DeleteDeviceBySigningKeyJwt = {
-                type: "DELETE_DEVICE_BY_SIGNING_KEY_JWT",
-                message: {
-                    jwtToken,
-                    publicSigningKey,
-                },
-            };
-            return FrameMediator.sendMessage<MT.DeleteDeviceResponse>(payload).map(({message}) => message);
-        })
-        .toPromise();
 
 /**
  * Lists all the devices for the currently logged in user.

--- a/src/shim/sdk/tests/UserSDK.test.ts
+++ b/src/shim/sdk/tests/UserSDK.test.ts
@@ -143,4 +143,25 @@ describe("UserSDK", () => {
                 .catch((e) => done(e));
         });
     });
+
+    describe("deleteDeviceByPublicSigningKeyWithJwt", () => {
+        it("sends the frame delete message, doesn't send delete request type to frame", (done) => {
+            ShimUtils.clearSDKInitialized();
+            jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
+            UserSDK.deleteDeviceByPublicSigningKeyWithJwt(() => Promise.resolve("jwt"), "signingKey")
+                .then((result: any) => {
+                    expect(result).toEqual(10);
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DELETE_DEVICE_BY_SIGNING_KEY_JWT",
+                        message: {
+                            publicSigningKey: "signingKey",
+                            jwtToken: "jwt",
+                        },
+                    });
+                    expect(ShimUtils.clearParentWindowSymmetricKey).not.toHaveBeenCalled();
+                    done();
+                })
+                .catch((e) => done(e));
+        });
+    });
 });

--- a/src/shim/sdk/tests/UserSDK.test.ts
+++ b/src/shim/sdk/tests/UserSDK.test.ts
@@ -143,25 +143,4 @@ describe("UserSDK", () => {
                 .catch((e) => done(e));
         });
     });
-
-    describe("deleteDeviceByPublicSigningKeyWithJwt", () => {
-        it("sends the frame delete message, doesn't send delete request type to frame", (done) => {
-            ShimUtils.clearSDKInitialized();
-            jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
-            UserSDK.deleteDeviceByPublicSigningKeyWithJwt(() => Promise.resolve("jwt"), "signingKey")
-                .then((result: any) => {
-                    expect(result).toEqual(10);
-                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
-                        type: "DELETE_DEVICE_BY_SIGNING_KEY_JWT",
-                        message: {
-                            publicSigningKey: "signingKey",
-                            jwtToken: "jwt",
-                        },
-                    });
-                    expect(ShimUtils.clearParentWindowSymmetricKey).not.toHaveBeenCalled();
-                    done();
-                })
-                .catch((e) => done(e));
-        });
-    });
 });

--- a/src/shim/tests/Initialize.test.ts
+++ b/src/shim/tests/Initialize.test.ts
@@ -431,4 +431,26 @@ describe("Initialize", () => {
                 });
         });
     });
+
+    describe("deleteDeviceByPublicSigningKey", () => {
+        it("sends the frame delete message, doesn't send delete request type to frame", (done) => {
+            ShimUtils.clearSDKInitialized();
+            jest.spyOn(ShimUtils, "clearParentWindowSymmetricKey");
+            jest.spyOn(FrameMediator, "sendMessage").mockReturnValue(Future.of<any>({message: 10}));
+            Initialize.deleteDeviceByPublicSigningKey(() => Promise.resolve("jwt"), "signingKey")
+                .then((result: any) => {
+                    expect(result).toEqual(10);
+                    expect(FrameMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "DELETE_DEVICE_BY_SIGNING_KEY_JWT",
+                        message: {
+                            publicSigningKey: "signingKey",
+                            jwtToken: "jwt",
+                        },
+                    });
+                    expect(ShimUtils.clearParentWindowSymmetricKey).not.toHaveBeenCalled();
+                    done();
+                })
+                .catch((e) => done(e));
+        });
+    });
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1424117/191368902-7135e0e6-86c4-44a1-b6c5-36798bd6b473.png)

This allows someone with access to a jwt for a user to delete a device without logging in and creating another one.