### PR TITLE
Fix publishing CI

### DIFF
--- a/.github/scripts/publish.js
+++ b/.github/scripts/publish.js
@@ -31,6 +31,12 @@ if (args.indexOf("--version") === -1) {
     shell.echo("You must provide the version of ironweb to publish publicly with the '--version' argument, e.g. '--version 1.2.3'.");
     shell.exit(-1);
 }
+
+if (process.env.NODE_AUTH_TOKEN == "") {
+    shell.echo("\n\nEnvironment variable NODE_AUTH_TOKEN must be set in order to download @ironcorelabs/ironweb-internal.");
+    shell.exit(0);
+}
+
 const PUBLISH_VERSION = args[args.indexOf("--version") + 1];
 const SHOULD_PUBLISH = args.indexOf("--publish") !== -1;
 const PRODUCTION_FRAME_FILE_URL = `https://api.ironcorelabs.com/static/ironweb-frame-${PUBLISH_VERSION}/ironweb-frame.min.js`;
@@ -74,6 +80,8 @@ https.get(PRODUCTION_FRAME_FILE_URL, (response) => {
     shell.pushd("./publish");
     //Pull down the private internal ironweb content from NPM and move things around so we can republish it under the public name
     shell.exec(`npm install @ironcorelabs/ironweb-internal@${PUBLISH_VERSION} --no-save --production`);
+    // We use Trusted Publishing to publish, so we can't have this env var set anymore
+    shell.exec("unset NODE_AUTH_TOKEN");
     shell.mv("./node_modules/@ironcorelabs/ironweb-internal/*", "./");
     shell.rm("-rf", "./node_modules");
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  snapshot:
+  publish:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -29,3 +29,6 @@ jobs:
           echo "/usr/local/bin" >> $GITHUB_PATH
       - name: Publish release to @ironcorelabs/ironweb
         run: yarn && node ./.github/scripts/publish.js --version ${{ inputs.version }} --publish
+        env:
+          # Needed in order to download @ironcorelabs/ironweb-internal; publishing will use Trusted Publishing instead
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The IronWeb SDK NPM releases follow standard [Semantic Versioning](https://semve
 
 **Note:** The patch versions of the IronWeb SDK will not be sequential and might jump by multiple numbers between sequential releases.
 
-## v4.2.46
+## v4.2.47
 - update `qs` to fix a security vulnerability
 - switch release process to [Trusted Publishing](https://docs.npmjs.com/trusted-publishers)
 


### PR DESCRIPTION
We need a token to download ironweb-internal, and then unset the token's env var to make it use Trusted Publishing