### PR TITLE
Fix local key encryption issue

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -81,7 +81,8 @@ interface EncryptedLocalKeys {
     encryptedDeviceKey: Uint8Array;
     encryptedSigningKey: Uint8Array;
     symmetricKey: Uint8Array;
-    iv: Uint8Array;
+    deviceIv: Uint8Array;
+    signingIv: Uint8Array;
 }
 interface WorkerEvent<T> {
     replyID: number;

--- a/src/WorkerMessageTypes.d.ts
+++ b/src/WorkerMessageTypes.d.ts
@@ -50,12 +50,7 @@ export interface DeviceKeygenWorkerResponse {
 
 export interface DecryptLocalKeysWorkerRequest {
     type: "DECRYPT_LOCAL_KEYS";
-    message: {
-        encryptedDeviceKey: Uint8Array;
-        encryptedSigningKey: Uint8Array;
-        symmetricKey: Uint8Array;
-        nonce: Uint8Array;
-    };
+    message: EncryptedLocalKeys;
 }
 export interface DecryptLocalKeysWorkerResponse {
     type: "DECRYPT_LOCAL_KEYS_RESPONSE";
@@ -69,6 +64,19 @@ export interface DecryptLocalKeysWorkerResponse {
             privateKey: Uint8Array;
         };
     };
+}
+
+export interface ReEncryptLocalKeysWorkerRequest {
+    type: "REENCRYPT_LOCAL_KEYS";
+    message: {
+        devicePrivateKey: Uint8Array;
+        signingPrivateKey: Uint8Array;
+        symmetricKey: Uint8Array;
+    };
+}
+export interface ReEncryptLocalKeysWorkerResponse {
+    type: "REENCRYPT_LOCAL_KEYS_RESPONSE";
+    message: EncryptedLocalKeys;
 }
 
 export interface RotateUserPrivateKeyWorkerRequest {
@@ -302,6 +310,7 @@ export type RequestMessage =
     | ChangeUserPasscodeWorkerRequest
     | GroupCreateWorkerRequest
     | DecryptLocalKeysWorkerRequest
+    | ReEncryptLocalKeysWorkerRequest
     | GroupAddAdminWorkerRequest
     | GroupAddMemberWorkerRequest
     | SignatureGenerationWorkerRequest
@@ -320,6 +329,7 @@ export type ResponseMessage =
     | NewUserAndDeviceKeygenWorkerResponse
     | DeviceKeygenWorkerResponse
     | DecryptLocalKeysWorkerResponse
+    | ReEncryptLocalKeysWorkerResponse
     | ChangeUserPasscodeWorkerResponse
     | GroupCreateWorkerResponse
     | GroupAddAdminWorkerResponse

--- a/src/frame/FrameMessenger.ts
+++ b/src/frame/FrameMessenger.ts
@@ -37,7 +37,10 @@ export default class FrameMessenger {
         const {data, replyID}: FrameEvent<RequestMessage> = event.data;
         this.onMessageCallback(data, (responseData: ResponseMessage, transferList: Uint8Array[] = []) => {
             if (this.messagePort) {
-                this.messagePort.postMessage({replyID, data: responseData}, transferList.map((int8Array) => int8Array.buffer));
+                this.messagePort.postMessage(
+                    {replyID, data: responseData},
+                    transferList.map((int8Array) => int8Array.buffer)
+                );
             }
         });
     };

--- a/src/frame/FrameUtils.ts
+++ b/src/frame/FrameUtils.ts
@@ -26,15 +26,18 @@ const requestStorageAccess = (): Future<never, boolean> =>
  * Given a device and signing private key, combine them together, stringify, and set them in local storage
  * @param {string}                 userID            Users provided ID
  * @param {number}                 segmentID         ID of segment to which user belongs
- * @param {PrivateKey<Uint8Array>} devicePrivateKey  Users device private key
- * @param {PrivateKey<Uint8Array>} signingPrivateKey Users signing private key
+ * @param {PrivateKey<Uint8Array>} devicePrivateKey  Users encrypted device private key
+ * @param {PrivateKey<Uint8Array>} signingPrivateKey Users encrypted signing private key
+ * @param {Uint8Array}             deviceIv          IV used for device key encryption
+ * @param {Uint8Array}             signingIv         IV used for signing key encryption
  */
 export const storeDeviceAndSigningKeys = (
     userID: string,
     segmentID: number,
     devicePrivateKey: PrivateKey<Uint8Array>,
     signingPrivateKey: PrivateKey<Uint8Array>,
-    nonce: Uint8Array
+    deviceIv: Uint8Array,
+    signingIv: Uint8Array
 ): Future<never, void> => {
     const store = () => {
         localStorage.setItem(
@@ -42,7 +45,8 @@ export const storeDeviceAndSigningKeys = (
             JSON.stringify({
                 deviceKey: fromByteArray(devicePrivateKey),
                 signingKey: fromByteArray(signingPrivateKey),
-                nonce: fromByteArray(nonce),
+                deviceIv: fromByteArray(deviceIv),
+                signingIv: fromByteArray(signingIv),
             })
         );
     };
@@ -81,25 +85,45 @@ export function clearDeviceAndSigningKeys(userID: string, segmentID: number) {
     }
 }
 
+export interface LocalEncryptedKeys {
+    encryptedDeviceKey: Uint8Array;
+    encryptedSigningKey: Uint8Array;
+    deviceIv: Uint8Array;
+    signingIv: Uint8Array;
+    // True if keys are stored in old single-IV format and need re-encryption with separate IVs
+    needsMigration: boolean;
+}
+
 /**
  * Attempt to read out the signing and device keys from local storage. Will return with null if keys don't exists or can't be parsed
  * @param {string} userID    Users provided ID
  * @param {number} segmentID ID of segment to which user belongs
  */
-export function getDeviceAndSigningKeys(
-    userID: string,
-    segmentID: number
-): Future<Error, {encryptedDeviceKey: Uint8Array; encryptedSigningKey: Uint8Array; nonce: Uint8Array}> {
+export function getDeviceAndSigningKeys(userID: string, segmentID: number): Future<Error, LocalEncryptedKeys> {
     let keys: any;
     try {
         keys = JSON.parse(localStorage.getItem(generateFrameStorageKey(userID, segmentID)) as any);
         if (!keys || typeof keys !== "object" || !keys.deviceKey || !keys.signingKey || !keys.deviceKey.length || !keys.signingKey.length) {
             throw new Error("Invalid local keys");
         }
+        // Detect old format: has single 'nonce' field instead of separate deviceIv/signingIv
+        const hasOldFormat = keys.nonce && !keys.deviceIv;
+        if (hasOldFormat) {
+            const sharedIv = toByteArray(keys.nonce);
+            return Future.of({
+                encryptedDeviceKey: toByteArray(keys.deviceKey),
+                encryptedSigningKey: toByteArray(keys.signingKey),
+                deviceIv: sharedIv,
+                signingIv: sharedIv,
+                needsMigration: true,
+            });
+        }
         return Future.of({
             encryptedDeviceKey: toByteArray(keys.deviceKey),
             encryptedSigningKey: toByteArray(keys.signingKey),
-            nonce: toByteArray(keys.nonce),
+            deviceIv: toByteArray(keys.deviceIv),
+            signingIv: toByteArray(keys.signingIv),
+            needsMigration: false,
         });
     } catch (e: any) {
         clearDeviceAndSigningKeys(userID, segmentID);

--- a/src/frame/endpoints/tests/DocumentApiEndpoints.test.ts
+++ b/src/frame/endpoints/tests/DocumentApiEndpoints.test.ts
@@ -368,26 +368,26 @@ describe("DocumentApiEndpoints", () => {
                 () => {
                     throw new Error("Doc grant should not reject");
                 },
-                    () => {
-                        const request = (ApiRequest.makeAuthorizedApiRequest as unknown as jest.SpyInstance).mock.calls[0][2];
-                        expect(JSON.parse(request.body)).toEqual({
-                            fromPublicKey: {x: TestUtils.userPublicXString, y: TestUtils.userPublicYString},
-                            to: [
-                                {
-                                    encryptedMessage: "AAAA",
-                                    publicSigningKey: "AA==",
-                                    authHash: "AA==",
-                                    signature: "A===",
-                                    ephemeralPublicKey: {x: "AAAAAAA=", y: "AAAAA=="},
-                                    userOrGroup: {
-                                        type: "group",
-                                        id: "355",
-                                        masterPublicKey: {x: "grouppublickeyx", y: "grouppublickeyy"},
-                                    },
+                () => {
+                    const request = (ApiRequest.makeAuthorizedApiRequest as unknown as jest.SpyInstance).mock.calls[0][2];
+                    expect(JSON.parse(request.body)).toEqual({
+                        fromPublicKey: {x: TestUtils.userPublicXString, y: TestUtils.userPublicYString},
+                        to: [
+                            {
+                                encryptedMessage: "AAAA",
+                                publicSigningKey: "AA==",
+                                authHash: "AA==",
+                                signature: "A===",
+                                ephemeralPublicKey: {x: "AAAAAAA=", y: "AAAAA=="},
+                                userOrGroup: {
+                                    type: "group",
+                                    id: "355",
+                                    masterPublicKey: {x: "grouppublickeyx", y: "grouppublickeyy"},
                                 },
-                            ],
-                        });
-                    }
+                            },
+                        ],
+                    });
+                }
             );
         });
 
@@ -396,38 +396,38 @@ describe("DocumentApiEndpoints", () => {
                 () => {
                     throw new Error("Doc grant should not reject");
                 },
-                    () => {
-                        const request = (ApiRequest.makeAuthorizedApiRequest as unknown as jest.SpyInstance).mock.calls[0][2];
-                        expect(JSON.parse(request.body)).toEqual({
-                            fromPublicKey: {x: TestUtils.userPublicXString, y: TestUtils.userPublicYString},
-                            to: [
-                                {
-                                    encryptedMessage: "AAA=",
-                                    publicSigningKey: "AAAA",
-                                    authHash: "AA==",
-                                    signature: "A===",
-                                    ephemeralPublicKey: {x: "", y: "AA=="},
-                                    userOrGroup: {
-                                        type: "user",
-                                        id: "37",
-                                        masterPublicKey: {x: "firstpublickeyx", y: "firstpublickeyy"},
-                                    },
+                () => {
+                    const request = (ApiRequest.makeAuthorizedApiRequest as unknown as jest.SpyInstance).mock.calls[0][2];
+                    expect(JSON.parse(request.body)).toEqual({
+                        fromPublicKey: {x: TestUtils.userPublicXString, y: TestUtils.userPublicYString},
+                        to: [
+                            {
+                                encryptedMessage: "AAA=",
+                                publicSigningKey: "AAAA",
+                                authHash: "AA==",
+                                signature: "A===",
+                                ephemeralPublicKey: {x: "", y: "AA=="},
+                                userOrGroup: {
+                                    type: "user",
+                                    id: "37",
+                                    masterPublicKey: {x: "firstpublickeyx", y: "firstpublickeyy"},
                                 },
-                                {
-                                    encryptedMessage: "AA==",
-                                    publicSigningKey: "AA==",
-                                    authHash: "AA==",
-                                    signature: "A===",
-                                    ephemeralPublicKey: {x: "AAAAAA==", y: "AAAA"},
-                                    userOrGroup: {
-                                        type: "user",
-                                        id: "99",
-                                        masterPublicKey: {x: "secondpublickey", y: "secondpublickeyy"},
-                                    },
+                            },
+                            {
+                                encryptedMessage: "AA==",
+                                publicSigningKey: "AA==",
+                                authHash: "AA==",
+                                signature: "A===",
+                                ephemeralPublicKey: {x: "AAAAAA==", y: "AAAA"},
+                                userOrGroup: {
+                                    type: "user",
+                                    id: "99",
+                                    masterPublicKey: {x: "secondpublickey", y: "secondpublickeyy"},
                                 },
-                            ],
-                        });
-                    }
+                            },
+                        ],
+                    });
+                }
             );
         });
     });

--- a/src/frame/endpoints/tests/GroupApiEndpoints.test.ts
+++ b/src/frame/endpoints/tests/GroupApiEndpoints.test.ts
@@ -19,7 +19,9 @@ describe("GroupApiEndpoints", () => {
     describe("callGroupListApi", () => {
         it("requests group list endpoint and maps response to data result", () => {
             GroupApiEndpoints.callGroupListApi().engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (groups: any) => {
                     expect(groups).toEqual({foo: "bar"});
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledWith("groups", expect.any(Number), expect.any(Object));
@@ -42,7 +44,9 @@ describe("GroupApiEndpoints", () => {
             };
             apiSpy.mockReturnValue(Future.of<any>(apiResp));
             GroupApiEndpoints.callGroupKeyListApi([id1, id2]).engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (groups: any) => {
                     expect(groups).toEqual(apiResp);
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledWith("groups?id=group-10%2Cgroup-20", expect.any(Number), expect.any(Object));
@@ -63,7 +67,9 @@ describe("GroupApiEndpoints", () => {
             };
             apiSpy.mockReturnValue(Future.of<any>(apiResp));
             GroupApiEndpoints.callGroupKeyListApi([id1, id2]).engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (groups: any) => {
                     expect(groups).toEqual(apiResp);
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledWith(
@@ -77,7 +83,9 @@ describe("GroupApiEndpoints", () => {
 
         it("returns empty array if no group IDs provided", () => {
             GroupApiEndpoints.callGroupKeyListApi([]).engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (groups) => {
                     expect(groups).toEqual({result: []});
                     expect(ApiRequest.makeAuthorizedApiRequest).not.toHaveBeenCalled();
@@ -102,7 +110,9 @@ describe("GroupApiEndpoints", () => {
             for (var member in GroupApiEndpoints.groupPublicKeyCache) delete GroupApiEndpoints.groupPublicKeyCache[member];
             apiSpy.mockReturnValue(Future.of<any>(apiResp));
             GroupApiEndpoints.getGroupPublicKeyList([id1, id2]).engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (groups: any) => {
                     expect(groups).toEqual(apiResp.result);
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledWith("groups?id=group-10%2Cgroup-20", expect.any(Number), expect.any(Object));
@@ -110,7 +120,9 @@ describe("GroupApiEndpoints", () => {
                 }
             );
             GroupApiEndpoints.getGroupPublicKeyList([id1, id2]).engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (groups: any) => {
                     expect(groups).toEqual(apiResp.result);
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledTimes(1);
@@ -133,7 +145,9 @@ describe("GroupApiEndpoints", () => {
             for (var member in GroupApiEndpoints.groupPublicKeyCache) delete GroupApiEndpoints.groupPublicKeyCache[member];
             apiSpy.mockReturnValue(Future.of<any>(apiResp));
             GroupApiEndpoints.getGroupPublicKeyList([id1, id2]).engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (groups: any) => {
                     expect(groups).toEqual(apiResp.result);
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledWith("groups?id=group-10%2Cgroup-20", expect.any(Number), expect.any(Object));
@@ -158,7 +172,9 @@ describe("GroupApiEndpoints", () => {
             for (var member in GroupApiEndpoints.groupPublicKeyCache) delete GroupApiEndpoints.groupPublicKeyCache[member];
             apiSpy.mockReturnValue(Future.of<any>(apiResp));
             GroupApiEndpoints.getGroupPublicKeyList([id1, id2]).engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (groups: any) => {
                     expect(groups).toEqual(apiResp.result);
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledWith("groups?id=group-10%2Cgroup-20", expect.any(Number), expect.any(Object));
@@ -166,7 +182,9 @@ describe("GroupApiEndpoints", () => {
                 }
             );
             GroupApiEndpoints.getGroupPublicKeyList([id1, "group-30"]).engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (_) => {
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledWith("groups?id=group-10%2Cgroup-30", expect.any(Number), expect.any(Object));
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledTimes(2);
@@ -178,7 +196,9 @@ describe("GroupApiEndpoints", () => {
     describe("callGroupGetApi", () => {
         it("requests group get with specific ID and maps response to data result", () => {
             GroupApiEndpoints.callGroupGetApi("87").engage(
-                (e) => {throw e},
+                (e) => {
+                    throw e;
+                },
                 (group: any) => {
                     expect(group).toEqual({foo: "bar"});
                     expect(ApiRequest.makeAuthorizedApiRequest).toHaveBeenCalledWith("groups/87", expect.any(Number), expect.any(Object));

--- a/src/frame/initialization/InitializationApi.ts
+++ b/src/frame/initialization/InitializationApi.ts
@@ -3,7 +3,7 @@ import Future from "futurejs";
 import UserApiEndpoints, {UserCreationKeys} from "../endpoints/UserApiEndpoints";
 import * as WMT from "../../WorkerMessageTypes";
 import * as WorkerMediator from "../WorkerMediator";
-import {CryptoConstants} from "../../Constants";
+import {CryptoConstants, ErrorCodes} from "../../Constants";
 import {getDeviceAndSigningKeys} from "../FrameUtils";
 import {sliceArrayBuffer} from "../../lib/Utils";
 import SDKError from "../../lib/SDKError";
@@ -78,6 +78,19 @@ export function generateDeviceAndSigningKeys(jwtToken: string, passcode: string,
     });
 }
 
+export interface FetchedLocalKeys {
+    deviceKeys: {
+        publicKey: PublicKey<Uint8Array>;
+        privateKey: Uint8Array;
+    };
+    signingKeys: {
+        publicKey: SigningPublicKey<Uint8Array>;
+        privateKey: Uint8Array;
+    };
+    /** True if keys were in old single-IV format and need re-encryption */
+    needsMigration: boolean;
+}
+
 /**
  * Attempt to read a users device and signing keys from local storage. If they exist and appear to be valid, use them to generate the associated public
  * key and return both pairs
@@ -85,15 +98,41 @@ export function generateDeviceAndSigningKeys(jwtToken: string, passcode: string,
  * @param {number} segmentID            ID of segment user is a part of
  * @param {string} localKeySymmetricKey Users local symmetric key provided by parent window
  */
-export function fetchAndValidateLocalKeys(userID: string, segmentID: number, localKeySymmetricKey: string) {
-    return getDeviceAndSigningKeys(userID, segmentID).flatMap((localKeys) => {
-        const payload: WMT.DecryptLocalKeysWorkerRequest = {
-            type: "DECRYPT_LOCAL_KEYS",
-            message: {
-                ...localKeys,
-                symmetricKey: toByteArray(localKeySymmetricKey),
-            },
-        };
-        return WorkerMediator.sendMessage<WMT.DecryptLocalKeysWorkerResponse>(payload).map(({message}) => message);
-    });
+export function fetchAndValidateLocalKeys(userID: string, segmentID: number, localKeySymmetricKey: string): Future<SDKError, FetchedLocalKeys> {
+    return getDeviceAndSigningKeys(userID, segmentID)
+        .errorMap((error) => new SDKError(error, ErrorCodes.USER_DEVICE_KEY_DECRYPTION_FAILURE))
+        .flatMap((localKeys) => {
+            const payload: WMT.DecryptLocalKeysWorkerRequest = {
+                type: "DECRYPT_LOCAL_KEYS",
+                message: {
+                    encryptedDeviceKey: localKeys.encryptedDeviceKey,
+                    encryptedSigningKey: localKeys.encryptedSigningKey,
+                    symmetricKey: toByteArray(localKeySymmetricKey),
+                    deviceIv: localKeys.deviceIv,
+                    signingIv: localKeys.signingIv,
+                },
+            };
+            return WorkerMediator.sendMessage<WMT.DecryptLocalKeysWorkerResponse>(payload).map(({message}) => ({
+                ...message,
+                needsMigration: localKeys.needsMigration,
+            }));
+        });
+}
+
+/**
+ * Re-encrypt device and signing keys with new IVs for migration from old single-IV format.
+ * @param {Uint8Array} devicePrivateKey  Decrypted device private key
+ * @param {Uint8Array} signingPrivateKey Decrypted signing private key
+ * @param {string}     symmetricKey      Base64-encoded symmetric key
+ */
+export function reEncryptLocalKeys(devicePrivateKey: Uint8Array, signingPrivateKey: Uint8Array, symmetricKey: string) {
+    const payload: WMT.ReEncryptLocalKeysWorkerRequest = {
+        type: "REENCRYPT_LOCAL_KEYS",
+        message: {
+            devicePrivateKey,
+            signingPrivateKey,
+            symmetricKey: toByteArray(symmetricKey),
+        },
+    };
+    return WorkerMediator.sendMessage<WMT.ReEncryptLocalKeysWorkerResponse>(payload).map(({message}) => message);
 }

--- a/src/frame/initialization/index.ts
+++ b/src/frame/initialization/index.ts
@@ -55,9 +55,23 @@ const handleVerifyResult = (
             InitializationApi.fetchAndValidateLocalKeys(user.id, user.segmentId, deviceAndSigningSymmetricKey)
                 //We need to map this error to constrain the types to say we're returning a SDK Error, even though we'll always use the handleWith below. That's why the error code here is invalid.
                 .errorMap((e) => new SDKError(e, 0))
-                .map(({deviceKeys, signingKeys}) => {
+                .flatMap(({deviceKeys, signingKeys, needsMigration}) => {
                     ApiState.setDeviceAndSigningKeys(deviceKeys, signingKeys);
-                    return buildSDKInitCompleteResponse(user);
+                    // If keys were in old single-IV format, re-encrypt with proper two-IV format
+                    if (needsMigration) {
+                        return InitializationApi.reEncryptLocalKeys(deviceKeys.privateKey, signingKeys.privateKey, deviceAndSigningSymmetricKey).flatMap(
+                            (encryptedLocalKeys) =>
+                                storeDeviceAndSigningKeys(
+                                    user.id,
+                                    user.segmentId,
+                                    encryptedLocalKeys.encryptedDeviceKey,
+                                    encryptedLocalKeys.encryptedSigningKey,
+                                    encryptedLocalKeys.deviceIv,
+                                    encryptedLocalKeys.signingIv
+                                ).map(() => buildSDKInitCompleteResponse(user))
+                        );
+                    }
+                    return Future.of(buildSDKInitCompleteResponse(user));
                 })
                 //Handles the scenario where either
                 //  + We couldn't find a local set of encrypted device/signing keys
@@ -104,7 +118,8 @@ export const createUserAndDevice = (jwtToken: string, passcode: string): Future<
             user.segmentId,
             encryptedLocalKeys.encryptedDeviceKey,
             encryptedLocalKeys.encryptedSigningKey,
-            encryptedLocalKeys.iv
+            encryptedLocalKeys.deviceIv,
+            encryptedLocalKeys.signingIv
         ).map(() => buildSDKInitCompleteResponse(user, encryptedLocalKeys.symmetricKey));
     });
 
@@ -123,7 +138,8 @@ export const generateUserNewDeviceKeys = (jwtToken: string, passcode: string): F
                 segmentId,
                 encryptedLocalKeys.encryptedDeviceKey,
                 encryptedLocalKeys.encryptedSigningKey,
-                encryptedLocalKeys.iv
+                encryptedLocalKeys.deviceIv,
+                encryptedLocalKeys.signingIv
             ).map(() => buildSDKInitCompleteResponse(ApiState.user(), encryptedLocalKeys.symmetricKey));
         }
     );

--- a/src/frame/initialization/tests/InitializationApi.test.ts
+++ b/src/frame/initialization/tests/InitializationApi.test.ts
@@ -169,27 +169,70 @@ describe("InitializationApi", () => {
         it("looks up keys in local storage and returns public and private for device and signing", () => {
             const encryptedDeviceKey = new Uint8Array(33);
             const encryptedSigningKey = new Uint8Array(64);
-            const nonce = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
+            const decryptedKeys = {
+                deviceKeys: {publicKey: new Uint8Array(1), privateKey: new Uint8Array(2)},
+                signingKeys: {publicKey: new Uint8Array(3), privateKey: new Uint8Array(4)},
+            };
 
-            jest.spyOn(FrameUtils, "getDeviceAndSigningKeys").mockReturnValue(Future.of<any>({encryptedDeviceKey, encryptedSigningKey, nonce}));
+            jest.spyOn(FrameUtils, "getDeviceAndSigningKeys").mockReturnValue(
+                Future.of<any>({encryptedDeviceKey, encryptedSigningKey, deviceIv, signingIv, needsMigration: false})
+            );
 
-            jest.spyOn(WorkerMediator, "sendMessage").mockReturnValue(Future.of<any>({message: "decrypted keys"}));
+            jest.spyOn(WorkerMediator, "sendMessage").mockReturnValue(Future.of<any>({message: decryptedKeys}));
 
             InitApi.fetchAndValidateLocalKeys("30", 3, "AA==").engage(
                 (e) => {
                     throw e;
                 },
                 (response: any) => {
-                    expect(response).toEqual("decrypted keys");
+                    expect(response).toEqual({...decryptedKeys, needsMigration: false});
                     expect(WorkerMediator.sendMessage).toHaveBeenCalledWith({
                         type: expect.any(String),
                         message: {
                             encryptedDeviceKey,
                             encryptedSigningKey,
-                            nonce,
+                            deviceIv,
+                            signingIv,
                             symmetricKey: new Uint8Array(1),
                         },
                     });
+                }
+            );
+        });
+    });
+
+    describe("reEncryptLocalKeys", () => {
+        it("sends re-encryption request to worker with decrypted keys and symmetric key", (done) => {
+            const devicePrivateKey = new Uint8Array([1, 2, 3]);
+            const signingPrivateKey = new Uint8Array([4, 5, 6]);
+            const symmetricKey = "AQID"; // base64 for [1, 2, 3]
+            const encryptedResult = {
+                encryptedDeviceKey: new Uint8Array(32),
+                encryptedSigningKey: new Uint8Array(64),
+                deviceIv: new Uint8Array(12),
+                signingIv: new Uint8Array(12),
+                symmetricKey: new Uint8Array([1, 2, 3]),
+            };
+
+            jest.spyOn(WorkerMediator, "sendMessage").mockReturnValue(Future.of<any>({message: encryptedResult}));
+
+            InitApi.reEncryptLocalKeys(devicePrivateKey, signingPrivateKey, symmetricKey).engage(
+                (e) => {
+                    throw e;
+                },
+                (result: any) => {
+                    expect(result).toEqual(encryptedResult);
+                    expect(WorkerMediator.sendMessage).toHaveBeenCalledWith({
+                        type: "REENCRYPT_LOCAL_KEYS",
+                        message: {
+                            devicePrivateKey,
+                            signingPrivateKey,
+                            symmetricKey: new Uint8Array([1, 2, 3]),
+                        },
+                    });
+                    done();
                 }
             );
         });

--- a/src/frame/initialization/tests/index.test.ts
+++ b/src/frame/initialization/tests/index.test.ts
@@ -1,6 +1,7 @@
 import {fromByteArray} from "base64-js";
 import Future from "futurejs";
 import {ErrorCodes} from "../../../Constants";
+import SDKError from "../../../lib/SDKError";
 import {publicKeyToBase64} from "../../../lib/Utils";
 import * as TestUtils from "../../../tests/TestUtils";
 import ApiState from "../../ApiState";
@@ -101,7 +102,9 @@ describe("init index", () => {
         });
 
         it("expects passcode response when local keys cannot be found or validated", (done) => {
-            jest.spyOn(InitializationApi, "fetchAndValidateLocalKeys").mockReturnValue(Future.reject(new Error("failed")));
+            jest.spyOn(InitializationApi, "fetchAndValidateLocalKeys").mockReturnValue(
+                Future.reject(new SDKError(new Error("failed"), ErrorCodes.USER_DEVICE_KEY_DECRYPTION_FAILURE))
+            );
 
             jest.spyOn(InitializationApi, "initializeApi").mockReturnValue(
                 Future.of<any>({
@@ -135,7 +138,7 @@ describe("init index", () => {
 
             const deviceKeys = TestUtils.getEmptyKeyPair();
             const signingKeys = TestUtils.getSigningKeyPair();
-            jest.spyOn(InitializationApi, "fetchAndValidateLocalKeys").mockReturnValue(Future.of<any>({deviceKeys, signingKeys}));
+            jest.spyOn(InitializationApi, "fetchAndValidateLocalKeys").mockReturnValue(Future.of<any>({deviceKeys, signingKeys, needsMigration: false}));
 
             Init.initialize("jwtToken", "symKey").engage(
                 (e) => {
@@ -159,6 +162,58 @@ describe("init index", () => {
                     expect(ApiState.signingKeys()).toEqual(signingKeys);
                     expect(ApiState.user()).toEqual(TestUtils.getFullUser());
                     expect(InitializationApi.fetchAndValidateLocalKeys).toHaveBeenCalledWith("user-10", 1, "symKey");
+                    done();
+                }
+            );
+        });
+
+        it("re-encrypts and stores keys when needsMigration is true", (done) => {
+            jest.spyOn(InitializationApi, "initializeApi").mockReturnValue(
+                Future.of<any>({
+                    user: TestUtils.getFullUser(),
+                })
+            );
+
+            const deviceKeys = TestUtils.getEmptyKeyPair();
+            const signingKeys = TestUtils.getSigningKeyPair();
+            jest.spyOn(InitializationApi, "fetchAndValidateLocalKeys").mockReturnValue(Future.of<any>({deviceKeys, signingKeys, needsMigration: true}));
+            jest.spyOn(InitializationApi, "reEncryptLocalKeys").mockReturnValue(
+                Future.of<any>({
+                    encryptedDeviceKey: new Uint8Array([1, 2, 3]),
+                    encryptedSigningKey: new Uint8Array([4, 5, 6]),
+                    deviceIv: new Uint8Array([7, 8, 9]),
+                    signingIv: new Uint8Array([10, 11, 12]),
+                    symmetricKey: new Uint8Array([13, 14, 15]),
+                })
+            );
+            jest.spyOn(FrameUtils, "storeDeviceAndSigningKeys").mockReturnValue(Future.of<any>(undefined));
+
+            Init.initialize("jwtToken", "symKey").engage(
+                (e) => {
+                    throw e;
+                },
+                (SDK) => {
+                    expect(SDK).toEqual({
+                        type: "FULL_SDK_RESPONSE",
+                        message: {
+                            user: {
+                                id: "user-10",
+                                needsRotation: false,
+                                status: 1,
+                            },
+                            groupsNeedingRotation: [],
+                            symmetricKey: undefined,
+                        },
+                    });
+                    expect(InitializationApi.reEncryptLocalKeys).toHaveBeenCalledWith(deviceKeys.privateKey, signingKeys.privateKey, "symKey");
+                    expect(FrameUtils.storeDeviceAndSigningKeys).toHaveBeenCalledWith(
+                        "user-10",
+                        1,
+                        new Uint8Array([1, 2, 3]),
+                        new Uint8Array([4, 5, 6]),
+                        new Uint8Array([7, 8, 9]),
+                        new Uint8Array([10, 11, 12])
+                    );
                     done();
                 }
             );
@@ -223,7 +278,8 @@ describe("init index", () => {
                         encryptedDeviceKey: "edk",
                         encryptedSigningKey: "esk",
                         symmetricKey: "sk",
-                        iv: "iv",
+                        deviceIv: "deviceIv",
+                        signingIv: "signingIv",
                     },
                 })
             );
@@ -251,7 +307,7 @@ describe("init index", () => {
                     expect(ApiState.signingKeys()).toEqual(signingKeys);
                     expect(ApiState.user()).toEqual(TestUtils.getFullUser());
 
-                    expect(FrameUtils.storeDeviceAndSigningKeys).toHaveBeenCalledWith("user-10", 1, "edk", "esk", "iv");
+                    expect(FrameUtils.storeDeviceAndSigningKeys).toHaveBeenCalledWith("user-10", 1, "edk", "esk", "deviceIv", "signingIv");
                 }
             );
         });
@@ -274,7 +330,8 @@ describe("init index", () => {
                         encryptedDeviceKey: "edk",
                         encryptedSigningKey: "esk",
                         symmetricKey: "sk",
-                        iv: "iv",
+                        deviceIv: "deviceIv",
+                        signingIv: "signingIv",
                     },
                     userUpdateKeys: {deviceKeys, signingKeys},
                 })
@@ -307,7 +364,7 @@ describe("init index", () => {
                     expect(ApiState.deviceKeys()).toEqual(deviceKeys);
                     expect(ApiState.signingKeys()).toEqual(signingKeys);
 
-                    expect(FrameUtils.storeDeviceAndSigningKeys).toHaveBeenCalledWith("user-10", 1, "edk", "esk", "iv");
+                    expect(FrameUtils.storeDeviceAndSigningKeys).toHaveBeenCalledWith("user-10", 1, "edk", "esk", "deviceIv", "signingIv");
                 }
             );
         });

--- a/src/frame/protobuf/EncryptedDeks.d.ts
+++ b/src/frame/protobuf/EncryptedDeks.d.ts
@@ -1,23 +1,19 @@
 import * as $protobuf from "protobufjs";
 /** Namespace ironcorelabs. */
 export namespace ironcorelabs {
-
     /** Namespace proto. */
     namespace proto {
-
         /** Properties of a PublicKey. */
         interface IPublicKey {
-
             /** PublicKey x */
-            x?: (Uint8Array|null);
+            x?: Uint8Array | null;
 
             /** PublicKey y */
-            y?: (Uint8Array|null);
+            y?: Uint8Array | null;
         }
 
         /** Represents a PublicKey. */
         class PublicKey implements IPublicKey {
-
             /**
              * Constructs a new PublicKey.
              * @param [properties] Properties to set
@@ -49,20 +45,18 @@ export namespace ironcorelabs {
 
         /** Properties of a UserOrGroup. */
         interface IUserOrGroup {
-
             /** UserOrGroup userId */
-            userId?: (string|null);
+            userId?: string | null;
 
             /** UserOrGroup groupId */
-            groupId?: (string|null);
+            groupId?: string | null;
 
             /** UserOrGroup masterPublicKey */
-            masterPublicKey?: (ironcorelabs.proto.IPublicKey|null);
+            masterPublicKey?: ironcorelabs.proto.IPublicKey | null;
         }
 
         /** Represents a UserOrGroup. */
         class UserOrGroup implements IUserOrGroup {
-
             /**
              * Constructs a new UserOrGroup.
              * @param [properties] Properties to set
@@ -76,10 +70,10 @@ export namespace ironcorelabs {
             public groupId: string;
 
             /** UserOrGroup masterPublicKey. */
-            public masterPublicKey?: (ironcorelabs.proto.IPublicKey|null);
+            public masterPublicKey?: ironcorelabs.proto.IPublicKey | null;
 
             /** UserOrGroup UserOrGroupId. */
-            public UserOrGroupId?: ("userId"|"groupId");
+            public UserOrGroupId?: "userId" | "groupId";
 
             /**
              * Encodes the specified UserOrGroup message. Does not implicitly {@link ironcorelabs.proto.UserOrGroup.verify|verify} messages.
@@ -100,26 +94,24 @@ export namespace ironcorelabs {
 
         /** Properties of an EncryptedDekData. */
         interface IEncryptedDekData {
-
             /** EncryptedDekData encryptedBytes */
-            encryptedBytes?: (Uint8Array|null);
+            encryptedBytes?: Uint8Array | null;
 
             /** EncryptedDekData ephemeralPublicKey */
-            ephemeralPublicKey?: (ironcorelabs.proto.IPublicKey|null);
+            ephemeralPublicKey?: ironcorelabs.proto.IPublicKey | null;
 
             /** EncryptedDekData signature */
-            signature?: (Uint8Array|null);
+            signature?: Uint8Array | null;
 
             /** EncryptedDekData authHash */
-            authHash?: (Uint8Array|null);
+            authHash?: Uint8Array | null;
 
             /** EncryptedDekData publicSigningKey */
-            publicSigningKey?: (Uint8Array|null);
+            publicSigningKey?: Uint8Array | null;
         }
 
         /** Represents an EncryptedDekData. */
         class EncryptedDekData implements IEncryptedDekData {
-
             /**
              * Constructs a new EncryptedDekData.
              * @param [properties] Properties to set
@@ -130,7 +122,7 @@ export namespace ironcorelabs {
             public encryptedBytes: Uint8Array;
 
             /** EncryptedDekData ephemeralPublicKey. */
-            public ephemeralPublicKey?: (ironcorelabs.proto.IPublicKey|null);
+            public ephemeralPublicKey?: ironcorelabs.proto.IPublicKey | null;
 
             /** EncryptedDekData signature. */
             public signature: Uint8Array;
@@ -160,17 +152,15 @@ export namespace ironcorelabs {
 
         /** Properties of an EncryptedDek. */
         interface IEncryptedDek {
-
             /** EncryptedDek userOrGroup */
-            userOrGroup?: (ironcorelabs.proto.IUserOrGroup|null);
+            userOrGroup?: ironcorelabs.proto.IUserOrGroup | null;
 
             /** EncryptedDek encryptedDekData */
-            encryptedDekData?: (ironcorelabs.proto.IEncryptedDekData|null);
+            encryptedDekData?: ironcorelabs.proto.IEncryptedDekData | null;
         }
 
         /** Represents an EncryptedDek. */
         class EncryptedDek implements IEncryptedDek {
-
             /**
              * Constructs a new EncryptedDek.
              * @param [properties] Properties to set
@@ -178,10 +168,10 @@ export namespace ironcorelabs {
             constructor(properties?: ironcorelabs.proto.IEncryptedDek);
 
             /** EncryptedDek userOrGroup. */
-            public userOrGroup?: (ironcorelabs.proto.IUserOrGroup|null);
+            public userOrGroup?: ironcorelabs.proto.IUserOrGroup | null;
 
             /** EncryptedDek encryptedDekData. */
-            public encryptedDekData?: (ironcorelabs.proto.IEncryptedDekData|null);
+            public encryptedDekData?: ironcorelabs.proto.IEncryptedDekData | null;
 
             /**
              * Encodes the specified EncryptedDek message. Does not implicitly {@link ironcorelabs.proto.EncryptedDek.verify|verify} messages.
@@ -202,20 +192,18 @@ export namespace ironcorelabs {
 
         /** Properties of an EncryptedDeks. */
         interface IEncryptedDeks {
-
             /** EncryptedDeks edeks */
-            edeks?: (ironcorelabs.proto.IEncryptedDek[]|null);
+            edeks?: ironcorelabs.proto.IEncryptedDek[] | null;
 
             /** EncryptedDeks documentId */
-            documentId?: (string|null);
+            documentId?: string | null;
 
             /** EncryptedDeks segmentId */
-            segmentId?: (number|null);
+            segmentId?: number | null;
         }
 
         /** Represents an EncryptedDeks. */
         class EncryptedDeks implements IEncryptedDeks {
-
             /**
              * Constructs a new EncryptedDeks.
              * @param [properties] Properties to set

--- a/src/frame/protobuf/EncryptedDeks.js
+++ b/src/frame/protobuf/EncryptedDeks.js
@@ -2,13 +2,13 @@
 import * as $protobuf from "protobufjs/minimal";
 
 // Common aliases
-const $Writer = $protobuf.Writer, $util = $protobuf.util;
+const $Writer = $protobuf.Writer,
+    $util = $protobuf.util;
 
 // Exported root namespace
 const $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
 
-export const ironcorelabs = $root.ironcorelabs = (() => {
-
+export const ironcorelabs = ($root.ironcorelabs = (() => {
     /**
      * Namespace ironcorelabs.
      * @exports ironcorelabs
@@ -16,8 +16,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
      */
     const ironcorelabs = {};
 
-    ironcorelabs.proto = (function() {
-
+    ironcorelabs.proto = (function () {
         /**
          * Namespace proto.
          * @memberof ironcorelabs
@@ -25,8 +24,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
          */
         const proto = {};
 
-        proto.PublicKey = (function() {
-
+        proto.PublicKey = (function () {
             /**
              * Properties of a PublicKey.
              * @memberof ironcorelabs.proto
@@ -45,9 +43,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              */
             function PublicKey(properties) {
                 if (properties)
-                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i) if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
             }
 
             /**
@@ -76,12 +72,9 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              * @returns {$protobuf.Writer} Writer
              */
             PublicKey.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.x != null && message.hasOwnProperty("x"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.x);
-                if (message.y != null && message.hasOwnProperty("y"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.y);
+                if (!writer) writer = $Writer.create();
+                if (message.x != null && message.hasOwnProperty("x")) writer.uint32(/* id 1, wireType 2 =*/ 10).bytes(message.x);
+                if (message.y != null && message.hasOwnProperty("y")) writer.uint32(/* id 2, wireType 2 =*/ 18).bytes(message.y);
                 return writer;
             };
 
@@ -101,8 +94,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
             return PublicKey;
         })();
 
-        proto.UserOrGroup = (function() {
-
+        proto.UserOrGroup = (function () {
             /**
              * Properties of a UserOrGroup.
              * @memberof ironcorelabs.proto
@@ -122,9 +114,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              */
             function UserOrGroup(properties) {
                 if (properties)
-                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i) if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
             }
 
             /**
@@ -161,8 +151,8 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              * @instance
              */
             Object.defineProperty(UserOrGroup.prototype, "UserOrGroupId", {
-                get: $util.oneOfGetter($oneOfFields = ["userId", "groupId"]),
-                set: $util.oneOfSetter($oneOfFields)
+                get: $util.oneOfGetter(($oneOfFields = ["userId", "groupId"])),
+                set: $util.oneOfSetter($oneOfFields),
             });
 
             /**
@@ -175,14 +165,11 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              * @returns {$protobuf.Writer} Writer
              */
             UserOrGroup.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.userId != null && message.hasOwnProperty("userId"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.userId);
-                if (message.groupId != null && message.hasOwnProperty("groupId"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.groupId);
+                if (!writer) writer = $Writer.create();
+                if (message.userId != null && message.hasOwnProperty("userId")) writer.uint32(/* id 1, wireType 2 =*/ 10).string(message.userId);
+                if (message.groupId != null && message.hasOwnProperty("groupId")) writer.uint32(/* id 2, wireType 2 =*/ 18).string(message.groupId);
                 if (message.masterPublicKey != null && message.hasOwnProperty("masterPublicKey"))
-                    $root.ironcorelabs.proto.PublicKey.encode(message.masterPublicKey, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                    $root.ironcorelabs.proto.PublicKey.encode(message.masterPublicKey, writer.uint32(/* id 3, wireType 2 =*/ 26).fork()).ldelim();
                 return writer;
             };
 
@@ -202,8 +189,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
             return UserOrGroup;
         })();
 
-        proto.EncryptedDekData = (function() {
-
+        proto.EncryptedDekData = (function () {
             /**
              * Properties of an EncryptedDekData.
              * @memberof ironcorelabs.proto
@@ -225,9 +211,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              */
             function EncryptedDekData(properties) {
                 if (properties)
-                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i) if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
             }
 
             /**
@@ -280,18 +264,15 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              * @returns {$protobuf.Writer} Writer
              */
             EncryptedDekData.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
+                if (!writer) writer = $Writer.create();
                 if (message.encryptedBytes != null && message.hasOwnProperty("encryptedBytes"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).bytes(message.encryptedBytes);
+                    writer.uint32(/* id 1, wireType 2 =*/ 10).bytes(message.encryptedBytes);
                 if (message.ephemeralPublicKey != null && message.hasOwnProperty("ephemeralPublicKey"))
-                    $root.ironcorelabs.proto.PublicKey.encode(message.ephemeralPublicKey, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
-                if (message.signature != null && message.hasOwnProperty("signature"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.signature);
-                if (message.authHash != null && message.hasOwnProperty("authHash"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).bytes(message.authHash);
+                    $root.ironcorelabs.proto.PublicKey.encode(message.ephemeralPublicKey, writer.uint32(/* id 2, wireType 2 =*/ 18).fork()).ldelim();
+                if (message.signature != null && message.hasOwnProperty("signature")) writer.uint32(/* id 3, wireType 2 =*/ 26).bytes(message.signature);
+                if (message.authHash != null && message.hasOwnProperty("authHash")) writer.uint32(/* id 4, wireType 2 =*/ 34).bytes(message.authHash);
                 if (message.publicSigningKey != null && message.hasOwnProperty("publicSigningKey"))
-                    writer.uint32(/* id 5, wireType 2 =*/42).bytes(message.publicSigningKey);
+                    writer.uint32(/* id 5, wireType 2 =*/ 42).bytes(message.publicSigningKey);
                 return writer;
             };
 
@@ -311,8 +292,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
             return EncryptedDekData;
         })();
 
-        proto.EncryptedDek = (function() {
-
+        proto.EncryptedDek = (function () {
             /**
              * Properties of an EncryptedDek.
              * @memberof ironcorelabs.proto
@@ -331,9 +311,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              */
             function EncryptedDek(properties) {
                 if (properties)
-                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i) if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
             }
 
             /**
@@ -362,12 +340,11 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              * @returns {$protobuf.Writer} Writer
              */
             EncryptedDek.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
+                if (!writer) writer = $Writer.create();
                 if (message.userOrGroup != null && message.hasOwnProperty("userOrGroup"))
-                    $root.ironcorelabs.proto.UserOrGroup.encode(message.userOrGroup, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    $root.ironcorelabs.proto.UserOrGroup.encode(message.userOrGroup, writer.uint32(/* id 1, wireType 2 =*/ 10).fork()).ldelim();
                 if (message.encryptedDekData != null && message.hasOwnProperty("encryptedDekData"))
-                    $root.ironcorelabs.proto.EncryptedDekData.encode(message.encryptedDekData, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                    $root.ironcorelabs.proto.EncryptedDekData.encode(message.encryptedDekData, writer.uint32(/* id 2, wireType 2 =*/ 18).fork()).ldelim();
                 return writer;
             };
 
@@ -387,8 +364,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
             return EncryptedDek;
         })();
 
-        proto.EncryptedDeks = (function() {
-
+        proto.EncryptedDeks = (function () {
             /**
              * Properties of an EncryptedDeks.
              * @memberof ironcorelabs.proto
@@ -409,9 +385,7 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
             function EncryptedDeks(properties) {
                 this.edeks = [];
                 if (properties)
-                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
+                    for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i) if (properties[keys[i]] != null) this[keys[i]] = properties[keys[i]];
             }
 
             /**
@@ -448,15 +422,12 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
              * @returns {$protobuf.Writer} Writer
              */
             EncryptedDeks.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
+                if (!writer) writer = $Writer.create();
                 if (message.edeks != null && message.edeks.length)
                     for (let i = 0; i < message.edeks.length; ++i)
-                        $root.ironcorelabs.proto.EncryptedDek.encode(message.edeks[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
-                if (message.documentId != null && message.hasOwnProperty("documentId"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.documentId);
-                if (message.segmentId != null && message.hasOwnProperty("segmentId"))
-                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.segmentId);
+                        $root.ironcorelabs.proto.EncryptedDek.encode(message.edeks[i], writer.uint32(/* id 1, wireType 2 =*/ 10).fork()).ldelim();
+                if (message.documentId != null && message.hasOwnProperty("documentId")) writer.uint32(/* id 2, wireType 2 =*/ 18).string(message.documentId);
+                if (message.segmentId != null && message.hasOwnProperty("segmentId")) writer.uint32(/* id 3, wireType 0 =*/ 24).int32(message.segmentId);
                 return writer;
             };
 
@@ -480,6 +451,6 @@ export const ironcorelabs = $root.ironcorelabs = (() => {
     })();
 
     return ironcorelabs;
-})();
+})());
 
-export { $root as default };
+export {$root as default};

--- a/src/frame/sdk/UserApi.ts
+++ b/src/frame/sdk/UserApi.ts
@@ -89,8 +89,8 @@ export const deleteDeviceBySigningKey = (publicSigningKey: Base64String) =>
     UserApiEndpoints.callUserDeviceDeleteBySigningKey(publicSigningKey).map((r) => r.id);
 
 /**
-* Delete a device from the DB given the public signing key of the device. Uses JWT auth.
-*/
+ * Delete a device from the DB given the public signing key of the device. Uses JWT auth.
+ */
 export const deleteDeviceBySigningKeyWithJwt = (jwtToken: string, publicSigningKey: Base64String) =>
     UserApiEndpoints.callUserDeviceDeleteBySigningKeyWithJwt(jwtToken, publicSigningKey).map((r) => r.id);
 

--- a/src/frame/tests/FrameUtils.test.ts
+++ b/src/frame/tests/FrameUtils.test.ts
@@ -22,15 +22,17 @@ describe("FrameUtils", () => {
         it("sets keys in local storage under proper key", async () => {
             const deviceKey = new Uint8Array(5);
             const signingKey = new Uint8Array(6);
-            const nonce = new Uint8Array([88, 93, 91]);
-            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, nonce);
+            const deviceIv = new Uint8Array([88, 93, 91]);
+            const signingIv = new Uint8Array([99, 100, 101]);
+            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, deviceIv, signingIv);
             const keys = localStorage.getItem("1-3:30-icldaspkn");
             expect(keys).toEqual(expect.stringContaining(""));
             const decodeKeys = JSON.parse(keys as string);
             expect(typeof decodeKeys).toBe("object");
             expect(decodeKeys.deviceKey).toEqual("AAAAAAA=");
             expect(decodeKeys.signingKey).toEqual("AAAAAAAA");
-            expect(decodeKeys.nonce).toEqual("WF1b");
+            expect(decodeKeys.deviceIv).toEqual("WF1b");
+            expect(decodeKeys.signingIv).toEqual("Y2Rl");
         });
 
         it("requests access if it doesn't have it. When granted, stores.", async () => {
@@ -44,8 +46,9 @@ describe("FrameUtils", () => {
 
             const deviceKey = new Uint8Array(5);
             const signingKey = new Uint8Array(6);
-            const nonce = new Uint8Array([88, 93, 91]);
-            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, nonce);
+            const deviceIv = new Uint8Array([88, 93, 91]);
+            const signingIv = new Uint8Array([99, 100, 101]);
+            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, deviceIv, signingIv);
 
             const keys = localStorage.getItem("1-3:30-icldaspkn");
             expect(keys).toEqual(expect.stringContaining(""));
@@ -53,7 +56,8 @@ describe("FrameUtils", () => {
             expect(typeof decodeKeys).toBe("object");
             expect(decodeKeys.deviceKey).toEqual("AAAAAAA=");
             expect(decodeKeys.signingKey).toEqual("AAAAAAAA");
-            expect(decodeKeys.nonce).toEqual("WF1b");
+            expect(decodeKeys.deviceIv).toEqual("WF1b");
+            expect(decodeKeys.signingIv).toEqual("Y2Rl");
         });
 
         it("requests access if it doesn't have it. When not granted, does nothing.", async () => {
@@ -67,8 +71,9 @@ describe("FrameUtils", () => {
 
             const deviceKey = new Uint8Array(5);
             const signingKey = new Uint8Array(6);
-            const nonce = new Uint8Array([88, 93, 91]);
-            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, nonce);
+            const deviceIv = new Uint8Array([88, 93, 91]);
+            const signingIv = new Uint8Array([99, 100, 101]);
+            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, deviceIv, signingIv);
 
             const keys = localStorage.getItem("1-3:30-icldaspkn");
             expect(keys).toEqual(null);
@@ -83,12 +88,13 @@ describe("FrameUtils", () => {
 
             const deviceKey = new Uint8Array(5);
             const signingKey = new Uint8Array(6);
-            const nonce = new Uint8Array([88, 93, 91]);
+            const deviceIv = new Uint8Array([88, 93, 91]);
+            const signingIv = new Uint8Array([99, 100, 101]);
 
             // unset requestStorageAccess, like a browser that doesn't know about it.
             const oldRequest = document.requestStorageAccess;
             delete (document as any).requestStorageAccess;
-            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, nonce);
+            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, deviceIv, signingIv);
             document.requestStorageAccess = oldRequest;
 
             const keys = localStorage.getItem("1-3:30-icldaspkn");
@@ -191,8 +197,9 @@ describe("FrameUtils", () => {
         it("responds with keys found in local storage when valid", async () => {
             const deviceKey = new Uint8Array(5);
             const signingKey = new Uint8Array(6);
-            const nonce = new Uint8Array([88, 93, 91]);
-            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, nonce);
+            const deviceIv = new Uint8Array([88, 93, 91]);
+            const signingIv = new Uint8Array([99, 100, 101]);
+            await FrameUtils.storeDeviceAndSigningKeys("30", 3, deviceKey, signingKey, deviceIv, signingIv);
 
             FrameUtils.getDeviceAndSigningKeys("30", 3).engage(
                 (e) => {
@@ -201,7 +208,8 @@ describe("FrameUtils", () => {
                 (localKeys) => {
                     expect(localKeys.encryptedDeviceKey).toEqual(deviceKey);
                     expect(localKeys.encryptedSigningKey).toEqual(signingKey);
-                    expect(localKeys.nonce).toEqual(nonce);
+                    expect(localKeys.deviceIv).toEqual(deviceIv);
+                    expect(localKeys.signingIv).toEqual(signingIv);
                 }
             );
         });

--- a/src/frame/worker/UserCrypto.ts
+++ b/src/frame/worker/UserCrypto.ts
@@ -149,11 +149,20 @@ export function generateNewUserAndDeviceKeys(passcode: string) {
 /**
  * Attempt to read a users device and signing keys from local storage. If they exist and appear to be valid, use them to generate the associated public
  * key and return both pairs
- * @param {string} userID               User composite segment ID + provided user ID
- * @param {string} localKeySymmetricKey Users local symmetric key provided by parent window
+ * @param {Uint8Array} encryptedDeviceKey  Users encrypted device private key
+ * @param {Uint8Array} encryptedSigningKey Users encrypted signing private key
+ * @param {Uint8Array} symmetricKey        Symmetric key used for decryption
+ * @param {Uint8Array} deviceIv            IV used for device key encryption
+ * @param {Uint8Array} signingIv           IV used for signing key encryption
  */
-export function decryptDeviceAndSigningKeys(encryptedDeviceKey: Uint8Array, encryptedSigningKey: Uint8Array, symmetricKey: Uint8Array, nonce: Uint8Array) {
-    return AES.decryptDeviceAndSigningKeys(encryptedDeviceKey, encryptedSigningKey, symmetricKey, nonce)
+export function decryptDeviceAndSigningKeys(
+    encryptedDeviceKey: Uint8Array,
+    encryptedSigningKey: Uint8Array,
+    symmetricKey: Uint8Array,
+    deviceIv: Uint8Array,
+    signingIv: Uint8Array
+) {
+    return AES.decryptDeviceAndSigningKeys(encryptedDeviceKey, encryptedSigningKey, symmetricKey, deviceIv, signingIv)
         .flatMap(({deviceKey, signingKey}) =>
             Future.gather2(Recrypt.derivePublicKey(deviceKey), Recrypt.getPublicSigningKeyFromPrivate(signingKey)).map(
                 ([publicDeviceKey, publicSigningKey]) => ({
@@ -195,4 +204,17 @@ export function changeUsersPasscode(currentPasscode: string, newPasscode: string
  */
 export function signRequestPayload(segmentID: number, userID: string, signingKeys: SigningKeyPair, method: string, url: string, body?: BodyInit | null) {
     return Recrypt.createRequestSignature(segmentID, userID, signingKeys, method, url, body);
+}
+
+/**
+ * Re-encrypt device and signing keys with new IVs using existing symmetric key.
+ * Used to migrate from old single-IV format to secure two-IV format.
+ * @param {Uint8Array} devicePrivateKey  Users decrypted device private key
+ * @param {Uint8Array} signingPrivateKey Users decrypted signing private key
+ * @param {Uint8Array} symmetricKey      Existing symmetric key to reuse
+ */
+export function reEncryptDeviceAndSigningKeys(devicePrivateKey: Uint8Array, signingPrivateKey: Uint8Array, symmetricKey: Uint8Array) {
+    return AES.reEncryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey).errorMap(
+        (error) => new SDKError(error, ErrorCodes.USER_DEVICE_KEY_DECRYPTION_FAILURE)
+    );
 }

--- a/src/frame/worker/WorkerUtil.ts
+++ b/src/frame/worker/WorkerUtil.ts
@@ -49,8 +49,14 @@ export const onMessageCallback = (data: RequestMessage, callback: (message: Resp
                 data.message.encryptedDeviceKey,
                 data.message.encryptedSigningKey,
                 data.message.symmetricKey,
-                data.message.nonce
+                data.message.deviceIv,
+                data.message.signingIv
             ).engage(errorHandler, (deviceAndSigningKeys) => callback({type: "DECRYPT_LOCAL_KEYS_RESPONSE", message: deviceAndSigningKeys}));
+        case "REENCRYPT_LOCAL_KEYS":
+            return UserCrypto.reEncryptDeviceAndSigningKeys(data.message.devicePrivateKey, data.message.signingPrivateKey, data.message.symmetricKey).engage(
+                errorHandler,
+                (encryptedKeys) => callback({type: "REENCRYPT_LOCAL_KEYS_RESPONSE", message: encryptedKeys})
+            );
         case "ROTATE_USER_PRIVATE_KEY":
             return UserCrypto.rotatePrivateKey(data.message.passcode, data.message.encryptedPrivateUserKey).engage(errorHandler, (userRotationResult) =>
                 callback({type: "ROTATE_USER_PRIVATE_KEY_RESPONSE", message: userRotationResult})

--- a/src/frame/worker/crypto/CryptoUtils.ts
+++ b/src/frame/worker/crypto/CryptoUtils.ts
@@ -10,9 +10,9 @@ export function getCryptoSubtleApi(): SubtleCrypto {
 }
 
 /**
- * Generate random bytes, wrapped in a Future. 
+ * Generate random bytes, wrapped in a Future.
  * @param {number} size Number of bytes to generate
  */
 export function generateRandomBytes(size: number): Future<Error, Uint8Array> {
-        return Future.of(nativeCrypto.getRandomValues(new Uint8Array(size)))
+    return Future.of(nativeCrypto.getRandomValues(new Uint8Array(size)));
 }

--- a/src/frame/worker/crypto/aes/NativeAes.ts
+++ b/src/frame/worker/crypto/aes/NativeAes.ts
@@ -105,24 +105,27 @@ export function decryptDocument(encryptedDocument: Uint8Array, documentSymmetric
 }
 
 /**
- * Encrypt the users private device and signing keys using the provided symmetric key and IV
+ * Encrypt the users private device and signing keys using the provided symmetric key and separate IVs
  * @param {Uint8Array} devicePrivateKey  Users device private key
  * @param {Uint8Array} signingPrivateKey Users signing private key
  * @param {Uint8Array} symmetricKey      Symmetric key to use for encryption
- * @param {Uint8Array} iv                IV to use for encryption
+ * @param {Uint8Array} deviceIv          IV to use for device key encryption
+ * @param {Uint8Array} signingIv         IV to use for signing key encryption
  */
 export function encryptDeviceAndSigningKeys(
     devicePrivateKey: Uint8Array,
     signingPrivateKey: Uint8Array,
     symmetricKey: Uint8Array,
-    iv: Uint8Array
+    deviceIv: Uint8Array,
+    signingIv: Uint8Array
 ): Future<Error, EncryptedLocalKeys> {
     return importAesKey(symmetricKey)
         .flatMap((cryptoKey) => {
-            return Future.gather2(encryptDocument(devicePrivateKey, cryptoKey, iv), encryptDocument(signingPrivateKey, cryptoKey, iv));
+            return Future.gather2(encryptDocument(devicePrivateKey, cryptoKey, deviceIv), encryptDocument(signingPrivateKey, cryptoKey, signingIv));
         })
         .map(([encryptedDeviceKey, encryptedSigningKey]) => ({
-            iv,
+            deviceIv,
+            signingIv,
             symmetricKey,
             encryptedDeviceKey: encryptedDeviceKey.content,
             encryptedSigningKey: encryptedSigningKey.content,
@@ -130,16 +133,23 @@ export function encryptDeviceAndSigningKeys(
 }
 
 /**
- * Decrypt the users private device and signing keys using the provided symmetric key and IV
- * @param {Uint8Array} devicePrivateKey  Users device private key
- * @param {Uint8Array} signingPrivateKey Users signing private key
- * @param {Uint8Array} symmetricKey      Symmetric key to use for encryption
- * @param {Uint8Array} iv                IV to use for encryption
+ * Decrypt the users private device and signing keys using the provided symmetric key and separate IVs
+ * @param {Uint8Array} encryptedDeviceKey  Users encrypted device private key
+ * @param {Uint8Array} encryptedSigningKey Users encrypted signing private key
+ * @param {Uint8Array} symmetricKey        Symmetric key to use for decryption
+ * @param {Uint8Array} deviceIv            IV used for device key encryption
+ * @param {Uint8Array} signingIv           IV used for signing key encryption
  */
-export function decryptDeviceAndSigningKeys(devicePrivateKey: Uint8Array, signingPrivateKey: Uint8Array, symmetricKey: Uint8Array, iv: Uint8Array) {
+export function decryptDeviceAndSigningKeys(
+    encryptedDeviceKey: Uint8Array,
+    encryptedSigningKey: Uint8Array,
+    symmetricKey: Uint8Array,
+    deviceIv: Uint8Array,
+    signingIv: Uint8Array
+) {
     return importAesKey(symmetricKey)
         .flatMap((cryptoKey) => {
-            return Future.gather2(decryptDocument(devicePrivateKey, cryptoKey, iv), decryptDocument(signingPrivateKey, cryptoKey, iv));
+            return Future.gather2(decryptDocument(encryptedDeviceKey, cryptoKey, deviceIv), decryptDocument(encryptedSigningKey, cryptoKey, signingIv));
         })
         .map(([deviceKey, signingKey]) => ({deviceKey, signingKey}));
 }

--- a/src/frame/worker/crypto/aes/PolyfillAes.ts
+++ b/src/frame/worker/crypto/aes/PolyfillAes.ts
@@ -87,21 +87,24 @@ export function decryptDocument(encryptedDocument: Uint8Array, documentSymmetric
 }
 
 /**
- * Encrypt the users private device and signing keys using the provided symmetric key and IV
+ * Encrypt the users private device and signing keys using the provided symmetric key and separate IVs
  * @param {Uint8Array} devicePrivateKey  Users device private key
  * @param {Uint8Array} signingPrivateKey Users signing private key
  * @param {Uint8Array} symmetricKey      Symmetric key to use for encryption
- * @param {Uint8Array} iv                IV to use for encryption
+ * @param {Uint8Array} deviceIv          IV to use for device key encryption
+ * @param {Uint8Array} signingIv         IV to use for signing key encryption
  */
 export function encryptDeviceAndSigningKeys(
     devicePrivateKey: Uint8Array,
     signingPrivateKey: Uint8Array,
     symmetricKey: Uint8Array,
-    iv: Uint8Array
+    deviceIv: Uint8Array,
+    signingIv: Uint8Array
 ): Future<Error, EncryptedLocalKeys> {
-    return Future.gather2(encryptDocument(devicePrivateKey, symmetricKey, iv), encryptDocument(signingPrivateKey, symmetricKey, iv)).map(
+    return Future.gather2(encryptDocument(devicePrivateKey, symmetricKey, deviceIv), encryptDocument(signingPrivateKey, symmetricKey, signingIv)).map(
         ([encryptedDeviceKey, encryptedSigningKey]) => ({
-            iv,
+            deviceIv,
+            signingIv,
             symmetricKey,
             encryptedDeviceKey: encryptedDeviceKey.content,
             encryptedSigningKey: encryptedSigningKey.content,
@@ -110,14 +113,21 @@ export function encryptDeviceAndSigningKeys(
 }
 
 /**
- * Decrypt the users private device and signing keys using the provided symmetric key and IV
- * @param {Uint8Array} devicePrivateKey  Users device private key
- * @param {Uint8Array} signingPrivateKey Users signing private key
- * @param {Uint8Array} symmetricKey      Symmetric key to use for encryption
- * @param {Uint8Array} iv                IV to use for encryption
+ * Decrypt the users private device and signing keys using the provided symmetric key and separate IVs
+ * @param {Uint8Array} encryptedDeviceKey  Users encrypted device private key
+ * @param {Uint8Array} encryptedSigningKey Users encrypted signing private key
+ * @param {Uint8Array} symmetricKey        Symmetric key to use for decryption
+ * @param {Uint8Array} deviceIv            IV used for device key encryption
+ * @param {Uint8Array} signingIv           IV used for signing key encryption
  */
-export function decryptDeviceAndSigningKeys(devicePrivateKey: Uint8Array, signingPrivateKey: Uint8Array, symmetricKey: Uint8Array, iv: Uint8Array) {
-    return Future.gather2(decryptDocument(devicePrivateKey, symmetricKey, iv), decryptDocument(signingPrivateKey, symmetricKey, iv)).map(
+export function decryptDeviceAndSigningKeys(
+    encryptedDeviceKey: Uint8Array,
+    encryptedSigningKey: Uint8Array,
+    symmetricKey: Uint8Array,
+    deviceIv: Uint8Array,
+    signingIv: Uint8Array
+) {
+    return Future.gather2(decryptDocument(encryptedDeviceKey, symmetricKey, deviceIv), decryptDocument(encryptedSigningKey, symmetricKey, signingIv)).map(
         ([deviceKey, signingKey]) => ({deviceKey, signingKey})
     );
 }

--- a/src/frame/worker/crypto/aes/index.ts
+++ b/src/frame/worker/crypto/aes/index.ts
@@ -41,9 +41,9 @@ export function encryptUserKey(decryptedPrivateUserKey: Uint8Array, derivedKey: 
  */
 export function encryptDocument(decryptedDocument: Uint8Array, documentSymmetricKey: Uint8Array): Future<Error, EncryptedDocument> {
     return generateRandomBytes(IV_LENGTH).flatMap((iv) => {
-            return NativeAes.encryptDocument(decryptedDocument, documentSymmetricKey, iv).handleWith(() =>
-                PolyfillAes.encryptDocument(decryptedDocument, documentSymmetricKey, iv)
-            );
+        return NativeAes.encryptDocument(decryptedDocument, documentSymmetricKey, iv).handleWith(() =>
+            PolyfillAes.encryptDocument(decryptedDocument, documentSymmetricKey, iv)
+        );
     });
 }
 
@@ -54,44 +54,82 @@ export function encryptDocument(decryptedDocument: Uint8Array, documentSymmetric
  * @param {Uint8Array} dataNonce            Nonce/IV to use to decrypt
  */
 export function decryptDocument(encryptedDocument: Uint8Array, documentSymmetricKey: Uint8Array, dataNonce: Uint8Array) {
-        return NativeAes.decryptDocument(encryptedDocument, documentSymmetricKey, dataNonce).handleWith((error) => {
-            //Don't attempt to invoke polyfill if decryption failed because the key was wrong. In that case the polyfill
-            //will obviously fail as well and we'll just waste cycles trying to decrypt.
-            if (error.name === NATIVE_DECRYPT_FAILURE_ERROR) {
-                //We have to cast to any because handleWith says we should be able to handle this, but in this case, we don't want to
-                return Future.reject(new Error("Decryption of document content failed.")) as any;
-            }
-            return PolyfillAes.decryptDocument(encryptedDocument, documentSymmetricKey, dataNonce);
-        })
+    return NativeAes.decryptDocument(encryptedDocument, documentSymmetricKey, dataNonce).handleWith((error) => {
+        //Don't attempt to invoke polyfill if decryption failed because the key was wrong. In that case the polyfill
+        //will obviously fail as well and we'll just waste cycles trying to decrypt.
+        if (error.name === NATIVE_DECRYPT_FAILURE_ERROR) {
+            //We have to cast to any because handleWith says we should be able to handle this, but in this case, we don't want to
+            return Future.reject(new Error("Decryption of document content failed.")) as any;
+        }
+        return PolyfillAes.decryptDocument(encryptedDocument, documentSymmetricKey, dataNonce);
+    });
 }
 
 /**
- * Encrypt the users private device and signing keys. Generates a random symmetric key and IV to encrypt the two keys.
+ * Generate a random symmetric key and two separate IVs from a single block of random bytes.
+ */
+export function generateKeyAndIvs(): Future<Error, {symmetricKey: Uint8Array; deviceIv: Uint8Array; signingIv: Uint8Array}> {
+    return generateRandomBytes(IV_LENGTH * 2 + AES_SYMMETRIC_KEY_LENGTH).map((bytes) => ({
+        symmetricKey: sliceArrayBuffer(bytes, 0, AES_SYMMETRIC_KEY_LENGTH),
+        deviceIv: sliceArrayBuffer(bytes, AES_SYMMETRIC_KEY_LENGTH, AES_SYMMETRIC_KEY_LENGTH + IV_LENGTH),
+        signingIv: sliceArrayBuffer(bytes, AES_SYMMETRIC_KEY_LENGTH + IV_LENGTH),
+    }));
+}
+
+/**
+ * Encrypt the users private device and signing keys. Generates a random symmetric key and two separate IVs
+ * (one for each key) to encrypt them securely. Using separate IVs is critical for AES-GCM security.
  * @param {Uint8Array} devicePrivateKey  Users device private key
  * @param {Uint8Array} signingPrivateKey Users signing private key
  */
 export function encryptDeviceAndSigningKeys(devicePrivateKey: Uint8Array, signingPrivateKey: Uint8Array): Future<Error, EncryptedLocalKeys> {
-    return generateRandomBytes(IV_LENGTH + AES_SYMMETRIC_KEY_LENGTH)
-        .map((symmetricKeyAndIVBytes) => ({
-            symmetricKey: sliceArrayBuffer(symmetricKeyAndIVBytes, 0, AES_SYMMETRIC_KEY_LENGTH),
-            iv: sliceArrayBuffer(symmetricKeyAndIVBytes, AES_SYMMETRIC_KEY_LENGTH),
-        }))
-        .flatMap(({symmetricKey, iv}) => {
-            return NativeAes.encryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey, iv).handleWith(() =>
-                PolyfillAes.encryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey, iv)
-            )
+    return generateKeyAndIvs().flatMap(({symmetricKey, deviceIv, signingIv}) => {
+            return NativeAes.encryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey, deviceIv, signingIv).handleWith(() =>
+                PolyfillAes.encryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey, deviceIv, signingIv)
+            );
         });
 }
 
 /**
- * Decrypt the users private device and signing keys using the provided symmetric key and IV that were used to encrypt the keys.
- * @param {Uint8Array} devicePrivateKey  Users device private key
- * @param {Uint8Array} signingPrivateKey Users signing private key
- * @param {Uint8Array} symmetricKey      Symmetric key to use for encryption
- * @param {Uint8Array} iv                IV/nonce to use for encryption
+ * Decrypt the users private device and signing keys using the provided symmetric key and IVs that were used to encrypt the keys.
+ * @param {Uint8Array} encryptedDeviceKey  Users encrypted device private key
+ * @param {Uint8Array} encryptedSigningKey Users encrypted signing private key
+ * @param {Uint8Array} symmetricKey        Symmetric key to use for decryption
+ * @param {Uint8Array} deviceIv            IV used for device key encryption
+ * @param {Uint8Array} signingIv           IV used for signing key encryption
  */
-export function decryptDeviceAndSigningKeys(devicePrivateKey: Uint8Array, signingPrivateKey: Uint8Array, symmetricKey: Uint8Array, iv: Uint8Array) {
-    return NativeAes.decryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey, iv).handleWith(() =>
-        PolyfillAes.decryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey, iv)
-    )
+export function decryptDeviceAndSigningKeys(
+    encryptedDeviceKey: Uint8Array,
+    encryptedSigningKey: Uint8Array,
+    symmetricKey: Uint8Array,
+    deviceIv: Uint8Array,
+    signingIv: Uint8Array
+) {
+    return NativeAes.decryptDeviceAndSigningKeys(encryptedDeviceKey, encryptedSigningKey, symmetricKey, deviceIv, signingIv).handleWith(() =>
+        PolyfillAes.decryptDeviceAndSigningKeys(encryptedDeviceKey, encryptedSigningKey, symmetricKey, deviceIv, signingIv)
+    );
+}
+
+/**
+ * Re-encrypt the users private device and signing keys with the existing symmetric key but new IVs.
+ * Used to migrate from old single-IV format to the secure two-IV format.
+ * @param {Uint8Array} devicePrivateKey  Users decrypted device private key
+ * @param {Uint8Array} signingPrivateKey Users decrypted signing private key
+ * @param {Uint8Array} symmetricKey      Existing symmetric key to reuse
+ */
+export function reEncryptDeviceAndSigningKeys(
+    devicePrivateKey: Uint8Array,
+    signingPrivateKey: Uint8Array,
+    symmetricKey: Uint8Array
+): Future<Error, EncryptedLocalKeys> {
+    return generateRandomBytes(IV_LENGTH * 2)
+        .map((bytes) => ({
+            deviceIv: sliceArrayBuffer(bytes, 0, IV_LENGTH),
+            signingIv: sliceArrayBuffer(bytes, IV_LENGTH),
+        }))
+        .flatMap(({deviceIv, signingIv}) => {
+            return NativeAes.encryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey, deviceIv, signingIv).handleWith(() =>
+                PolyfillAes.encryptDeviceAndSigningKeys(devicePrivateKey, signingPrivateKey, symmetricKey, deviceIv, signingIv)
+            );
+        });
 }

--- a/src/frame/worker/crypto/aes/tests/NativeAes.test.ts
+++ b/src/frame/worker/crypto/aes/tests/NativeAes.test.ts
@@ -105,17 +105,19 @@ describe("NativeAes", () => {
     });
 
     describe("encryptDeviceAndSigningKeys", () => {
-        it("encrypts the two keys with the provided sym key and iv", (done) => {
+        it("encrypts the two keys with the provided sym key and separate IVs", (done) => {
             const deviceKey = new Uint8Array(6);
             const signingKey = new Uint8Array(10);
             const symKey = new Uint8Array(32);
-            const iv = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
 
-            NativeAes.encryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, iv).engage(
+            NativeAes.encryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, deviceIv, signingIv).engage(
                 () => done("AES encryption of keys should not fail"),
                 (encryptedKeys) => {
                     expect(encryptedKeys).toEqual({
-                        iv,
+                        deviceIv,
+                        signingIv,
                         symmetricKey: symKey,
                         encryptedDeviceKey: new Uint8Array([93, 82, 72]),
                         encryptedSigningKey: new Uint8Array([93, 82, 72]),
@@ -127,13 +129,14 @@ describe("NativeAes", () => {
     });
 
     describe("decryptDeviceAndSigningKeys", () => {
-        it("decypts the provided keys", (done) => {
+        it("decrypts the provided keys with separate IVs", (done) => {
             const deviceKey = new Uint8Array(8);
             const signingKey = new Uint8Array(10);
             const symKey = new Uint8Array(32);
-            const iv = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
 
-            NativeAes.decryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, iv).engage(
+            NativeAes.decryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, deviceIv, signingIv).engage(
                 () => done("AES decryption of keys should not fail"),
                 (encryptedKeys) => {
                     expect(encryptedKeys).toEqual({

--- a/src/frame/worker/crypto/aes/tests/PolyfillAes.test.ts
+++ b/src/frame/worker/crypto/aes/tests/PolyfillAes.test.ts
@@ -73,17 +73,19 @@ describe("PolyfillAes", () => {
     });
 
     describe("encryptDeviceAndSigningKeys", () => {
-        it("encrypts the two keys with the provided sym key and iv", (done) => {
+        it("encrypts the two keys with the provided sym key and separate IVs", (done) => {
             const deviceKey = new Uint8Array([35, 80]);
             const signingKey = new Uint8Array([73, 33, 89]);
             const symKey = new Uint8Array(32);
-            const providedIV = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
 
-            PolyfillAes.encryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, providedIV).engage(
+            PolyfillAes.encryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, deviceIv, signingIv).engage(
                 () => done("AES encryption of keys should not fail"),
                 (encryptedKeys) => {
                     expect(encryptedKeys).toEqual({
-                        iv: providedIV,
+                        deviceIv,
+                        signingIv,
                         symmetricKey: symKey,
                         encryptedDeviceKey: new Uint8Array([237, 247, 80, 81, 206, 50, 195, 202, 27, 37, 46, 249, 68, 150, 15, 37, 65, 182]),
                         encryptedSigningKey: new Uint8Array([135, 134, 25, 146, 165, 113, 127, 5, 215, 159, 166, 161, 122, 200, 192, 117, 146, 202, 178]),
@@ -95,13 +97,14 @@ describe("PolyfillAes", () => {
     });
 
     describe("decryptDeviceAndSigningKeys", () => {
-        it("decypts the provided keys", (done) => {
+        it("decrypts the provided keys with separate IVs", (done) => {
             const deviceKey = new Uint8Array([237, 247, 80, 81, 206, 50, 195, 202, 27, 37, 46, 249, 68, 150, 15, 37, 65, 182]);
             const signingKey = new Uint8Array([135, 134, 25, 146, 165, 113, 127, 5, 215, 159, 166, 161, 122, 200, 192, 117, 146, 202, 178]);
             const symKey = new Uint8Array(32);
-            const iv = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
 
-            PolyfillAes.decryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, iv).engage(
+            PolyfillAes.decryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, deviceIv, signingIv).engage(
                 () => done("AES decryption of keys should not fail"),
                 (encryptedKeys) => {
                     expect(encryptedKeys).toEqual({

--- a/src/frame/worker/crypto/aes/tests/index.test.ts
+++ b/src/frame/worker/crypto/aes/tests/index.test.ts
@@ -1,6 +1,7 @@
-import {decryptUserKey, encryptUserKey, encryptDocument, decryptDocument, encryptDeviceAndSigningKeys, decryptDeviceAndSigningKeys} from "../index";
+import {decryptUserKey, encryptUserKey, encryptDocument, decryptDocument, encryptDeviceAndSigningKeys, decryptDeviceAndSigningKeys, generateKeyAndIvs} from "../index";
 import * as NativeAes from "../NativeAes";
 import * as PolyfillAes from "../PolyfillAes";
+import * as CryptoUtils from "../../CryptoUtils";
 import Future from "futurejs";
 import {CryptoConstants} from "../../../../../Constants";
 
@@ -195,7 +196,13 @@ describe("AES", () => {
                 },
                 (decryptedDoc: any) => {
                     expect(decryptedDoc).toEqual({foo: "bar"});
-                    expect(NativeAes.encryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, expect.any(Uint8Array), expect.any(Uint8Array));
+                    expect(NativeAes.encryptDeviceAndSigningKeys).toHaveBeenCalledWith(
+                        deviceKey,
+                        signingKey,
+                        expect.any(Uint8Array),
+                        expect.any(Uint8Array),
+                        expect.any(Uint8Array)
+                    );
                 }
             );
         });
@@ -213,8 +220,42 @@ describe("AES", () => {
                 },
                 (decryptedDoc: any) => {
                     expect(decryptedDoc).toEqual({foo: "bar"});
-                    expect(PolyfillAes.encryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, expect.any(Uint8Array), expect.any(Uint8Array));
-                    expect(NativeAes.encryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, expect.any(Uint8Array), expect.any(Uint8Array));
+                    expect(PolyfillAes.encryptDeviceAndSigningKeys).toHaveBeenCalledWith(
+                        deviceKey,
+                        signingKey,
+                        expect.any(Uint8Array),
+                        expect.any(Uint8Array),
+                        expect.any(Uint8Array)
+                    );
+                    expect(NativeAes.encryptDeviceAndSigningKeys).toHaveBeenCalledWith(
+                        deviceKey,
+                        signingKey,
+                        expect.any(Uint8Array),
+                        expect.any(Uint8Array),
+                        expect.any(Uint8Array)
+                    );
+                }
+            );
+        });
+    });
+
+    describe("generateKeyAndIvs", () => {
+        it("slices random bytes into symmetricKey [0..32), deviceIv [32..44), signingIv [44..56)", (done) => {
+            // Create a 56-byte sequence where each byte equals its index
+            const mockBytes = new Uint8Array(CryptoConstants.AES_SYMMETRIC_KEY_LENGTH + CryptoConstants.IV_LENGTH * 2);
+            for (let i = 0; i < mockBytes.length; i++) {
+                mockBytes[i] = i;
+            }
+            jest.spyOn(CryptoUtils, "generateRandomBytes").mockReturnValue(Future.of(mockBytes));
+
+            generateKeyAndIvs().engage(
+                (e) => done(e),
+                ({symmetricKey, deviceIv, signingIv}) => {
+                    const {AES_SYMMETRIC_KEY_LENGTH: KEY, IV_LENGTH: IV} = CryptoConstants;
+                    expect(symmetricKey).toEqual(mockBytes.slice(0, KEY));
+                    expect(deviceIv).toEqual(mockBytes.slice(KEY, KEY + IV));
+                    expect(signingIv).toEqual(mockBytes.slice(KEY + IV, KEY + IV * 2));
+                    done();
                 }
             );
         });
@@ -227,15 +268,16 @@ describe("AES", () => {
             const deviceKey = new Uint8Array(40);
             const signingKey = new Uint8Array(32);
             const symKey = new Uint8Array(30);
-            const nonce = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
 
-            decryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, nonce).engage(
+            decryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, deviceIv, signingIv).engage(
                 () => {
                     throw new Error("document decryption should not fail");
                 },
                 (decryptedDoc: any) => {
                     expect(decryptedDoc).toEqual({foo: "bar"});
-                    expect(NativeAes.decryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, symKey, nonce);
+                    expect(NativeAes.decryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, symKey, deviceIv, signingIv);
                 }
             );
         });
@@ -247,16 +289,17 @@ describe("AES", () => {
             const deviceKey = new Uint8Array(40);
             const signingKey = new Uint8Array(32);
             const symKey = new Uint8Array(30);
-            const nonce = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
 
-            decryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, nonce).engage(
+            decryptDeviceAndSigningKeys(deviceKey, signingKey, symKey, deviceIv, signingIv).engage(
                 () => {
                     throw new Error("document decryption should not fail");
                 },
                 (decryptedDoc: any) => {
                     expect(decryptedDoc).toEqual({foo: "bar"});
-                    expect(PolyfillAes.decryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, symKey, nonce);
-                    expect(NativeAes.decryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, symKey, nonce);
+                    expect(PolyfillAes.decryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, symKey, deviceIv, signingIv);
+                    expect(NativeAes.decryptDeviceAndSigningKeys).toHaveBeenCalledWith(deviceKey, signingKey, symKey, deviceIv, signingIv);
                 }
             );
         });

--- a/src/frame/worker/tests/UserCrypto.test.ts
+++ b/src/frame/worker/tests/UserCrypto.test.ts
@@ -221,7 +221,8 @@ describe("UserCrypto", () => {
             const encryptedSigningKey = new Uint8Array(64);
             const deviceKey = new Uint8Array(22);
             const signingKey = new Uint8Array(53);
-            const nonce = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
             const symKey = new Uint8Array(30);
 
             const devicePublicKey = new Uint8Array(22);
@@ -230,7 +231,7 @@ describe("UserCrypto", () => {
             jest.spyOn(Recrypt, "getPublicSigningKeyFromPrivate").mockReturnValue(Future.of<any>(signingPublicKey));
             jest.spyOn(AES, "decryptDeviceAndSigningKeys").mockReturnValue(Future.of<any>({deviceKey, signingKey}));
 
-            UserCrypto.decryptDeviceAndSigningKeys(encryptedDeviceKey, encryptedSigningKey, symKey, nonce).engage(
+            UserCrypto.decryptDeviceAndSigningKeys(encryptedDeviceKey, encryptedSigningKey, symKey, deviceIv, signingIv).engage(
                 (e) => {
                     throw e;
                 },
@@ -245,7 +246,7 @@ describe("UserCrypto", () => {
                             privateKey: signingKey,
                         },
                     });
-                    expect(AES.decryptDeviceAndSigningKeys).toHaveBeenCalledWith(encryptedDeviceKey, encryptedSigningKey, symKey, nonce);
+                    expect(AES.decryptDeviceAndSigningKeys).toHaveBeenCalledWith(encryptedDeviceKey, encryptedSigningKey, symKey, deviceIv, signingIv);
                 }
             );
         });
@@ -253,12 +254,13 @@ describe("UserCrypto", () => {
         it("converts errors into sdk error with expected error code", () => {
             const encryptedDeviceKey = new Uint8Array(33);
             const encryptedSigningKey = new Uint8Array(64);
-            const nonce = new Uint8Array(12);
+            const deviceIv = new Uint8Array(12);
+            const signingIv = new Uint8Array(12);
             const symKey = new Uint8Array(30);
 
             jest.spyOn(AES, "decryptDeviceAndSigningKeys").mockReturnValue(Future.reject(new Error("decrypt key failure")));
 
-            UserCrypto.decryptDeviceAndSigningKeys(encryptedDeviceKey, encryptedSigningKey, symKey, nonce).engage(
+            UserCrypto.decryptDeviceAndSigningKeys(encryptedDeviceKey, encryptedSigningKey, symKey, deviceIv, signingIv).engage(
                 (error) => {
                     expect(error.message).toEqual("decrypt key failure");
                     expect(error.code).toEqual(ErrorCodes.USER_DEVICE_KEY_DECRYPTION_FAILURE);

--- a/src/frame/worker/tests/index.test.ts
+++ b/src/frame/worker/tests/index.test.ts
@@ -121,13 +121,14 @@ describe("worker", () => {
                     encryptedDeviceKey: "device",
                     encryptedSigningKey: "signing",
                     symmetricKey: "sym key",
-                    nonce: "nonce",
+                    deviceIv: "deviceIv",
+                    signingIv: "signingIv",
                 },
             };
 
             worker.onMessageCallback!(payload, (result: any) => {
                 expect(result).toEqual({type: expect.any(String), message: "decrypted keys"});
-                expect(UserCrypto.decryptDeviceAndSigningKeys).toHaveBeenCalledWith("device", "signing", "sym key", "nonce");
+                expect(UserCrypto.decryptDeviceAndSigningKeys).toHaveBeenCalledWith("device", "signing", "sym key", "deviceIv", "signingIv");
                 done();
             });
         });

--- a/src/shim/ShimUtils.ts
+++ b/src/shim/ShimUtils.ts
@@ -175,10 +175,16 @@ export function dedupeAccessLists(accessList: DocumentAccessList) {
     let userAccess: string[] = [];
     let groupAccess: string[] = [];
     if (accessList.users && accessList.users.length) {
-        userAccess = dedupeArray(accessList.users.map(({id}) => id), true);
+        userAccess = dedupeArray(
+            accessList.users.map(({id}) => id),
+            true
+        );
     }
     if (accessList.groups && accessList.groups.length) {
-        groupAccess = dedupeArray(accessList.groups.map(({id}) => id), true);
+        groupAccess = dedupeArray(
+            accessList.groups.map(({id}) => id),
+            true
+        );
     }
     return [userAccess, groupAccess];
 }

--- a/src/shim/tests/Initialize.test.ts
+++ b/src/shim/tests/Initialize.test.ts
@@ -8,7 +8,7 @@ import * as FrameMediator from "../FrameMediator";
 describe("Initialize", () => {
     describe("createNewUser", () => {
         it("rejects if JWT callback does not return a promise", (done) => {
-            const jwtCallback = () => ({} as any);
+            const jwtCallback = () => ({}) as any;
 
             Initialize.createNewUser(jwtCallback, "passcode", false)
                 .then(() => done("resolve should not be called when JWT CB is invalid"))
@@ -93,7 +93,7 @@ describe("Initialize", () => {
 
     describe("createUserDeviceKeys", () => {
         it("rejects if JWT callback does not return a promise", (done) => {
-            const jwtCallback = () => ({} as any);
+            const jwtCallback = () => ({}) as any;
 
             Initialize.createUserDeviceKeys(jwtCallback, "passcode")
                 .then(() => done("resolve should not be called when JWT CB is invalid"))
@@ -182,7 +182,7 @@ describe("Initialize", () => {
 
     describe("jwt failures", () => {
         it("rejects if JWT callback does not return a promise", (done) => {
-            const jwtCallback = () => ({} as any);
+            const jwtCallback = () => ({}) as any;
 
             Initialize.initialize(jwtCallback, jest.fn())
                 .then(() => done("resolve should not be called when JWT CB is invalid"))

--- a/src/shim/tests/ShimUtils.test.ts
+++ b/src/shim/tests/ShimUtils.test.ts
@@ -196,7 +196,10 @@ describe("ShimUtils", () => {
                 groups: [{id: "35"}, {id: "11"}, {id: "11"}, {id: "35"}, {id: "83"}],
             };
 
-            expect(ShimUtils.dedupeAccessLists(accessList)).toEqual([["5", "8", "13"], ["35", "11", "83"]]);
+            expect(ShimUtils.dedupeAccessLists(accessList)).toEqual([
+                ["5", "8", "13"],
+                ["35", "11", "83"],
+            ]);
         });
 
         it("returns empty arrays for users if not provided", () => {


### PR DESCRIPTION
When keys are stored in local storage we encrypt them. This was to split the trust between the hosting domain and the domain that hosts our transform service. There was an issue where the IV for encrypting the signing key was re-used for encrypting the device private key.

This fixes that issue by re-encrypting them using separate IVs and generating them correctly for all new devices.

Unfortunately this PR also contains many reformatting changes since prettier hadn't been run on many of the files. If this is a problem I can try to revert some of it. I'd prefer to just get it all fixed up though.